### PR TITLE
Knulli native integration: cached-ids export, batch cache CLI, service-aware menu

### DIFF
--- a/linux/knulli/integration/README.md
+++ b/linux/knulli/integration/README.md
@@ -1,0 +1,101 @@
+# Knulli Native Integration (dev prototype)
+
+Prototype of the native Knulli integration discussed with the Knulli devs,
+testable on a real device with a full revert path. It replaces the legacy
+retroarch.cfg patching with launch-time config generation and gives the proxy
+a toggle in the Knulli UI.
+
+## What it installs
+
+1. **User service** `/userdata/system/services/raofflineproxy`
+   - Appears automatically in EmulationStation -> System Settings -> Services
+     as an on/off toggle (persisted in `batocera.conf` `system.services`,
+     started at boot by `S99userservices`).
+   - Runs `raofflineproxy run-service` via `start-stop-daemon` - the proxy
+     server only, no config patching.
+   - Lives entirely in `/userdata`, so no rootfs change is needed for it.
+
+2. **configgen hook** in `libretroConfig.py` (rootfs, persisted via the
+   Knulli overlay mechanism)
+   - At every game launch, probes `127.0.0.1:<proxy_port>` (port read from
+     the app's `config.json`, default 8080).
+   - If the proxy is listening and RetroAchievements are enabled for a
+     supported core: sets `cheevos_custom_host`, keeps `cheevos_enable`
+     "true" even when Knulli thinks it is offline, and forces hardcore off.
+   - If the proxy is not running: clears `cheevos_custom_host`, restoring
+     stock behaviour (including clearing any stale value left by the legacy
+     patching mode).
+   - Marker-based and idempotent; a pristine backup
+     (`libretroConfig.py.raop-orig`) is kept next to the file.
+
+The sideloaded app bundle (`/userdata/system/raofflineproxy`) is a
+prerequisite and is left untouched; the pygame menu keeps working.
+
+## Usage
+
+```bash
+# from this directory, device reachable over SSH (Knulli default: root/linux)
+./deploy.sh root@<device-ip> install
+./deploy.sh root@<device-ip> status
+./deploy.sh root@<device-ip> uninstall     # full revert, keeps other overlay mods
+./deploy.sh root@<device-ip> purge         # revert + delete the whole rootfs overlay file
+```
+
+Install automatically stops legacy mode first (`stop-proxy`,
+`disable-autostart`) so retroarch.cfg is reverted before native mode takes
+over. Uninstall restores `libretroConfig.py` from the backup, removes the
+service, and re-persists the overlay - after that the device behaves exactly
+as before, and the legacy pygame-menu Start/Stop mode can be used again.
+Switching back and forth is safe in both directions.
+
+`purge` additionally deletes `/boot/boot/overlay`. Only use it if
+RAOfflineProxy is the only rootfs customization on the device.
+
+## EmulationStation integration (dev)
+
+The knulli ES fork checkout at `~/src/knulli-emulationstation` (branch
+`raofflineproxy-integration`, uncommitted) adds:
+
+- **Offline icon**: games whose achievements are cached by the proxy show
+  trophy+download (``) instead of the plain trophy in gamelists.
+  ES reads the id list the proxy exports to
+  `/userdata/system/.config/raofflineproxy/cached_game_ids.txt` (kept in sync
+  by the Python app on every cache mutation).
+- **Game options menu**: "CACHE ACHIEVEMENTS FOR OFFLINE PLAY" /
+  "REMOVE OFFLINE ACHIEVEMENT DATA" per game (runs `cache-rom` /
+  `remove-cached-game` via the proxy CLI).
+- **Gamelist options menu**: "CACHE ACHIEVEMENTS FOR OFFLINE PLAY (N)" for
+  all displayed games (runs the new `cache-roms --paths-file` batch CLI with
+  live progress).
+
+All entries only appear when the proxy launcher exists on the device, so the
+patch is inert on stock installs.
+
+Build (in `~/src/knulli-linux`, dockerized; `knulli.mk` mounts the ES
+checkout and `output/h700/local.mk` sets
+`KNULLI_EMULATIONSTATION_OVERRIDE_SRCDIR`):
+
+```bash
+make h700-pkg PKG=knulli-emulationstation
+```
+
+Deploy/revert the built binary on the device:
+
+```bash
+./deploy-es.sh root@<device-ip> install   # backs up /usr/bin/emulationstation.orig
+./deploy-es.sh root@<device-ip> revert
+```
+
+## Testing checklist
+
+- ES -> System Settings -> Services shows "raofflineproxy"; toggle starts and
+  stops the proxy (`deploy.sh ... status` to confirm).
+- With the service on: launch a RA-enabled game, check the proxy log
+  (`/userdata/system/.config/raofflineproxy/service.log`) for intercepted
+  requests; `retroarch.cfg` gets `cheevos_custom_host = "127.0.0.1:<port>"`
+  written by configgen at launch.
+- With the service off: launch a game, `cheevos_custom_host` is empty and
+  RA traffic goes direct.
+- Offline with the service on: game launches with achievements active from
+  cache; casual unlocks are queued.
+- Reboot with the service enabled: proxy is running afterwards.

--- a/linux/knulli/integration/deploy-es.sh
+++ b/linux/knulli/integration/deploy-es.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST="${1:?usage: deploy-es.sh root@<device-ip> [install|revert]}"
+ACTION="${2:-install}"
+ES_BINARY="${ES_BINARY:-/Users/dschkalee/src/knulli-linux/output/h700/target/usr/bin/emulationstation}"
+
+case "${ACTION}" in
+    install)
+        if [ ! -f "${ES_BINARY}" ]; then
+            echo "ERROR: built ES binary not found at ${ES_BINARY}" >&2
+            exit 1
+        fi
+        echo "-- Copying ES binary to device"
+        scp "${ES_BINARY}" "${HOST}:/userdata/system/emulationstation.raop"
+        ssh "${HOST}" '
+            set -e
+            mount -o remount,rw /
+            if [ ! -f /usr/bin/emulationstation.orig ]; then
+                cp /usr/bin/emulationstation /usr/bin/emulationstation.orig
+            fi
+            cp /userdata/system/emulationstation.raop /usr/bin/emulationstation
+            chmod 0755 /usr/bin/emulationstation
+            rm -f /userdata/system/emulationstation.raop
+            SAVE="$(command -v knulli-save-overlay || command -v batocera-save-overlay)"
+            "${SAVE}"
+            mount -o remount,ro / 2>/dev/null || true
+            /etc/init.d/S31emulationstation restart >/dev/null 2>&1 || killall emulationstation || true
+            echo "ES binary replaced (backup at /usr/bin/emulationstation.orig), ES restarting."
+        '
+        ;;
+    revert)
+        ssh "${HOST}" '
+            set -e
+            if [ ! -f /usr/bin/emulationstation.orig ]; then
+                echo "No backup found - nothing to revert."
+                exit 0
+            fi
+            mount -o remount,rw /
+            cp /usr/bin/emulationstation.orig /usr/bin/emulationstation
+            rm -f /usr/bin/emulationstation.orig
+            SAVE="$(command -v knulli-save-overlay || command -v batocera-save-overlay)"
+            "${SAVE}"
+            mount -o remount,ro / 2>/dev/null || true
+            /etc/init.d/S31emulationstation restart >/dev/null 2>&1 || killall emulationstation || true
+            echo "Stock ES binary restored, ES restarting."
+        '
+        ;;
+    *)
+        echo "unknown action: ${ACTION} (use install|revert)" >&2
+        exit 1
+        ;;
+esac

--- a/linux/knulli/integration/deploy.sh
+++ b/linux/knulli/integration/deploy.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST="${1:?usage: deploy.sh root@<device-ip> [install|uninstall|purge|status]}"
+ACTION="${2:-install}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REMOTE_DIR=/userdata/system/raop-native-dev
+
+echo "-- Copying integration files to ${HOST}:${REMOTE_DIR}"
+ssh "${HOST}" "mkdir -p ${REMOTE_DIR}/services"
+scp "${SCRIPT_DIR}/device/dev-install.sh" \
+    "${SCRIPT_DIR}/device/dev-uninstall.sh" \
+    "${SCRIPT_DIR}/device/patch_configgen.py" \
+    "${HOST}:${REMOTE_DIR}/"
+scp "${SCRIPT_DIR}/device/services/raofflineproxy" "${HOST}:${REMOTE_DIR}/services/"
+
+case "${ACTION}" in
+    install)
+        ssh "${HOST}" "bash ${REMOTE_DIR}/dev-install.sh"
+        ;;
+    uninstall)
+        ssh "${HOST}" "bash ${REMOTE_DIR}/dev-uninstall.sh"
+        ;;
+    purge)
+        ssh "${HOST}" "bash ${REMOTE_DIR}/dev-uninstall.sh --purge-overlay"
+        ;;
+    status)
+        ssh "${HOST}" "python3 ${REMOTE_DIR}/patch_configgen.py status; \
+            (command -v knulli-services || command -v batocera-services) >/dev/null 2>&1 && \
+            \$(command -v knulli-services || command -v batocera-services) list | grep -i raoffline || true; \
+            /userdata/system/raofflineproxy/bin/raofflineproxy status || true"
+        ;;
+    *)
+        echo "unknown action: ${ACTION} (use install|uninstall|purge|status)" >&2
+        exit 1
+        ;;
+esac

--- a/linux/knulli/integration/device/dev-install.sh
+++ b/linux/knulli/integration/device/dev-install.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APP_BIN=/userdata/system/raofflineproxy/bin/raofflineproxy
+SERVICE_DST=/userdata/system/services/raofflineproxy
+
+echo "== RAOfflineProxy native integration (dev install) =="
+
+if [ ! -d /userdata/system ]; then
+    echo "ERROR: /userdata/system not found - this does not look like a Knulli device" >&2
+    exit 1
+fi
+
+if [ ! -x "${APP_BIN}" ]; then
+    echo "ERROR: RAOfflineProxy app not found at ${APP_BIN}" >&2
+    echo "Install the regular sideload bundle first, then re-run this script." >&2
+    exit 1
+fi
+
+SERVICES_BIN="$(command -v knulli-services || command -v batocera-services || true)"
+if [ -z "${SERVICES_BIN}" ]; then
+    echo "ERROR: neither knulli-services nor batocera-services found" >&2
+    exit 1
+fi
+
+SAVE_OVERLAY_BIN="$(command -v knulli-save-overlay || command -v batocera-save-overlay || true)"
+if [ -z "${SAVE_OVERLAY_BIN}" ]; then
+    echo "ERROR: neither knulli-save-overlay nor batocera-save-overlay found" >&2
+    exit 1
+fi
+
+echo "-- Stopping legacy mode (reverts retroarch.cfg/batocera.conf patching)"
+"${APP_BIN}" stop-proxy || true
+"${APP_BIN}" disable-autostart || true
+
+echo "-- Installing user service to ${SERVICE_DST}"
+mkdir -p /userdata/system/services
+install -m 0755 "${SCRIPT_DIR}/services/raofflineproxy" "${SERVICE_DST}"
+
+echo "-- Patching configgen on the rootfs overlay"
+mount -o remount,rw /
+python3 "${SCRIPT_DIR}/patch_configgen.py" apply
+
+echo "-- Persisting rootfs overlay (${SAVE_OVERLAY_BIN})"
+"${SAVE_OVERLAY_BIN}"
+mount -o remount,ro / 2>/dev/null || true
+
+echo "-- Enabling and starting the service"
+"${SERVICES_BIN}" enable raofflineproxy
+"${SERVICES_BIN}" start raofflineproxy
+
+sleep 1
+echo "-- Proxy status"
+"${APP_BIN}" status || true
+
+echo ""
+echo "Done. The RAOfflineProxy toggle now appears in"
+echo "EmulationStation -> System Settings -> Services."
+echo "Games route RetroAchievements through the proxy whenever it is running."

--- a/linux/knulli/integration/device/dev-uninstall.sh
+++ b/linux/knulli/integration/device/dev-uninstall.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SERVICE_DST=/userdata/system/services/raofflineproxy
+OVERLAY_FILE=/boot/boot/overlay
+PURGE_OVERLAY=0
+
+if [ "$1" = "--purge-overlay" ]; then
+    PURGE_OVERLAY=1
+fi
+
+echo "== RAOfflineProxy native integration (dev uninstall) =="
+
+SERVICES_BIN="$(command -v knulli-services || command -v batocera-services || true)"
+SAVE_OVERLAY_BIN="$(command -v knulli-save-overlay || command -v batocera-save-overlay || true)"
+
+echo "-- Stopping and disabling the service"
+if [ -n "${SERVICES_BIN}" ]; then
+    "${SERVICES_BIN}" stop raofflineproxy || true
+    "${SERVICES_BIN}" disable raofflineproxy || true
+fi
+rm -f "${SERVICE_DST}"
+
+echo "-- Reverting configgen patch"
+mount -o remount,rw /
+python3 "${SCRIPT_DIR}/patch_configgen.py" revert
+
+if [ "${PURGE_OVERLAY}" -eq 1 ]; then
+    echo "-- Purging rootfs overlay file (${OVERLAY_FILE})"
+    echo "   WARNING: this discards ALL rootfs customizations, not just RAOfflineProxy's."
+    mount -o remount,rw /boot
+    rm -f "${OVERLAY_FILE}"
+    mount -o remount,ro /boot 2>/dev/null || true
+    echo "   Rootfs is pristine after the next reboot."
+else
+    if [ -n "${SAVE_OVERLAY_BIN}" ]; then
+        echo "-- Persisting reverted rootfs overlay (${SAVE_OVERLAY_BIN})"
+        "${SAVE_OVERLAY_BIN}"
+    fi
+fi
+mount -o remount,ro / 2>/dev/null || true
+
+echo ""
+echo "Done. Native integration removed."
+echo "The sideloaded app itself is untouched - the pygame menu and its"
+echo "legacy Start/Stop (retroarch.cfg patching) mode work as before."
+echo "Re-run dev-install.sh at any time to switch back to native mode."

--- a/linux/knulli/integration/device/patch_configgen.py
+++ b/linux/knulli/integration/device/patch_configgen.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Apply/revert the RAOfflineProxy dev hook in Knulli's configgen libretroConfig.py.
+
+The hook is inserted between markers so it is idempotent and can be stripped
+cleanly. A pristine backup (libretroConfig.py.raop-orig) is kept for revert.
+"""
+
+import argparse
+import glob
+import importlib.util
+import shutil
+import sys
+from pathlib import Path
+
+MARKER_BEGIN = "# >>> RAOfflineProxy dev integration"
+MARKER_END = "# <<< RAOfflineProxy dev integration"
+ANCHOR = "if system.isOptSet('integerscale')"
+BACKUP_SUFFIX = ".raop-orig"
+
+HOOK_BLOCK = """\
+    # >>> RAOfflineProxy dev integration
+    try:
+        raop_port = 8080
+        try:
+            import json as raop_json
+            with open('/userdata/system/.config/raofflineproxy/config.json') as raop_fh:
+                raop_port = int(raop_json.load(raop_fh).get('proxy_port', 8080))
+        except Exception:
+            pass
+        import socket as raop_socket
+        raop_sock = raop_socket.socket(raop_socket.AF_INET, raop_socket.SOCK_STREAM)
+        raop_sock.settimeout(0.25)
+        raop_running = raop_sock.connect_ex(('127.0.0.1', raop_port)) == 0
+        raop_sock.close()
+        raop_wanted = system.isOptSet('retroachievements') and system.getOptBoolean('retroachievements') == True
+        raop_core_ok = (system.config['core'] in coreToRetroachievements) or (system.isOptSet('cheevos_force') and system.getOptBoolean('cheevos_force') == True)
+        raop_proxy_on = (not system.isOptSet('retroachievements.proxy')) or (system.getOptBoolean('retroachievements.proxy') == True)
+        if raop_running and raop_wanted and raop_core_ok and raop_proxy_on:
+            retroarchConfig['cheevos_enable'] = 'true'
+            retroarchConfig['cheevos_custom_host'] = '127.0.0.1:%s' % raop_port
+            retroarchConfig['cheevos_hardcore_mode_enable'] = 'false'
+        else:
+            retroarchConfig['cheevos_custom_host'] = ''
+    except Exception:
+        retroarchConfig['cheevos_custom_host'] = ''
+    # <<< RAOfflineProxy dev integration
+
+"""
+
+
+def find_target() -> Path:
+    spec = importlib.util.find_spec("configgen")
+    if spec and spec.origin:
+        candidate = Path(spec.origin).parent / "generators" / "libretro" / "libretroConfig.py"
+        if candidate.is_file():
+            return candidate
+
+    patterns = [
+        "/usr/lib/python3*/site-packages/configgen/generators/libretro/libretroConfig.py",
+        "/usr/lib/python3*/dist-packages/configgen/generators/libretro/libretroConfig.py",
+    ]
+    for pattern in patterns:
+        matches = sorted(glob.glob(pattern))
+        if matches:
+            return Path(matches[0])
+
+    raise FileNotFoundError("configgen libretroConfig.py not found on this system")
+
+
+def clear_pycache(target: Path) -> None:
+    pycache = target.parent / "__pycache__"
+    if pycache.is_dir():
+        shutil.rmtree(pycache, ignore_errors=True)
+
+
+def backup_path(target: Path) -> Path:
+    return target.with_name(target.name + BACKUP_SUFFIX)
+
+
+def do_apply(target: Path) -> int:
+    text = target.read_text()
+
+    if MARKER_BEGIN in text:
+        print(f"already patched: {target}")
+        return 0
+
+    lines = text.splitlines(keepends=True)
+    anchor_index = next(
+        (i for i, line in enumerate(lines) if line.lstrip().startswith(ANCHOR)),
+        None,
+    )
+    if anchor_index is None:
+        print(f"ERROR: anchor not found in {target}; configgen layout changed, not patching", file=sys.stderr)
+        return 2
+
+    backup = backup_path(target)
+    if not backup.exists():
+        shutil.copy2(target, backup)
+
+    lines.insert(anchor_index, HOOK_BLOCK)
+    target.write_text("".join(lines))
+    clear_pycache(target)
+    print(f"patched: {target}")
+    print(f"backup:  {backup}")
+    return 0
+
+
+def do_revert(target: Path) -> int:
+    backup = backup_path(target)
+
+    if backup.exists():
+        backup_text = backup.read_text()
+        if MARKER_BEGIN in backup_text:
+            print(f"ERROR: backup {backup} itself contains the hook; refusing to restore it", file=sys.stderr)
+            return 2
+        shutil.copy2(backup, target)
+        backup.unlink()
+        clear_pycache(target)
+        print(f"reverted from backup: {target}")
+        return 0
+
+    text = target.read_text()
+    if MARKER_BEGIN not in text:
+        print(f"already clean: {target}")
+        return 0
+
+    lines = text.splitlines(keepends=True)
+    begin = next(i for i, line in enumerate(lines) if MARKER_BEGIN in line)
+    end = next(i for i, line in enumerate(lines) if MARKER_END in line)
+    del lines[begin : end + 1]
+    if begin < len(lines) and lines[begin].strip() == "":
+        del lines[begin]
+    target.write_text("".join(lines))
+    clear_pycache(target)
+    print(f"reverted by stripping markers: {target}")
+    return 0
+
+
+def do_status(target: Path) -> int:
+    text = target.read_text()
+    patched = MARKER_BEGIN in text
+    backup = backup_path(target)
+    print(f"file:    {target}")
+    print(f"patched: {'yes' if patched else 'no'}")
+    print(f"backup:  {backup if backup.exists() else 'none'}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=["apply", "revert", "status"])
+    parser.add_argument("--file", help="Override path to libretroConfig.py")
+    args = parser.parse_args()
+
+    target = Path(args.file) if args.file else find_target()
+    if not target.is_file():
+        print(f"ERROR: {target} does not exist", file=sys.stderr)
+        return 2
+
+    if args.action == "apply":
+        return do_apply(target)
+    if args.action == "revert":
+        return do_revert(target)
+    return do_status(target)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/linux/knulli/integration/device/services/raofflineproxy
+++ b/linux/knulli/integration/device/services/raofflineproxy
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+LAUNCHER=/userdata/system/raofflineproxy/bin/raofflineproxy
+PIDFILE=/var/run/raofflineproxy-service.pid
+
+start() {
+    echo -n "Starting raofflineproxy: "
+    if [ ! -x "${LAUNCHER}" ]; then
+        echo "failed (app not installed at ${LAUNCHER})"
+        return 1
+    fi
+    start-stop-daemon -S -b -q -m -p "${PIDFILE}" --exec "${LAUNCHER}" -- run-service
+    RETVAL=$?
+    echo "done"
+    return ${RETVAL}
+}
+
+stop() {
+    echo -n "Stopping raofflineproxy: "
+    start-stop-daemon -K -q -p "${PIDFILE}"
+    RETVAL=$?
+    rm -f "${PIDFILE}"
+    echo "done"
+    return ${RETVAL}
+}
+
+status() {
+    if start-stop-daemon --status -q -p "${PIDFILE}"; then
+        echo "started"
+    else
+        echo "stopped"
+    fi
+}
+
+restart() {
+    stop
+    start
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status
+        ;;
+    restart)
+        restart
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|status|restart}"
+        ;;
+esac
+
+exit $?

--- a/linux/raofflineproxy/batocera_conf.py
+++ b/linux/raofflineproxy/batocera_conf.py
@@ -129,10 +129,9 @@ def _sanitize_previous(config_data: dict, previous: dict) -> dict:
 
 
 def build_reverted_batocera_conf(content: str, previous: dict) -> str:
+    # global.retroachievements is the user's master toggle: the proxy may
+    # enable it on start but must never disable it on revert
     reverted = content
-    reverted = _restore_value(
-        reverted, RETROACHIEVEMENTS_KEY, previous.get(RETROACHIEVEMENTS_KEY)
-    )
     reverted = _restore_value(
         reverted,
         RETROACHIEVEMENTS_HARDCORE_KEY,

--- a/linux/raofflineproxy/es_export.py
+++ b/linux/raofflineproxy/es_export.py
@@ -1,0 +1,56 @@
+import json
+import logging
+import os
+
+from . import cache_keys
+from .config import CONFIG_DIR
+
+CACHED_IDS_FILE = CONFIG_DIR / "cached_game_ids.txt"
+LOGGER = logging.getLogger("raofflineproxy")
+
+_RELEVANT_PREFIXES = (cache_keys.PREFIX_PATCH, cache_keys.PREFIX_ACHIEVEMENTSETS)
+
+
+def key_affects_cached_game_ids(cache_key: str | None) -> bool:
+    if cache_key is None:
+        return True
+    return cache_key.startswith(_RELEVANT_PREFIXES)
+
+
+def collect_cached_game_ids(storage) -> set[int]:
+    ids: set[int] = set()
+
+    for entry in storage.get_all_cache_by_prefix(cache_keys.PREFIX_PATCH):
+        game_id = cache_keys.parse_game_id_from_patch_key(entry.get("cacheKey") or "")
+        if game_id is not None and game_id > 0:
+            ids.add(game_id)
+
+    for entry in storage.get_all_cache_by_prefix(cache_keys.PREFIX_ACHIEVEMENTSETS):
+        try:
+            payload = json.loads(entry["responseBody"])
+        except Exception:
+            continue
+        game_id = payload.get("GameId")
+        if isinstance(game_id, int) and game_id > 0:
+            ids.add(game_id)
+
+    return ids
+
+
+def export_cached_game_ids(storage) -> None:
+    try:
+        content = "".join(
+            f"{game_id}\n" for game_id in sorted(collect_cached_game_ids(storage))
+        )
+        try:
+            if CACHED_IDS_FILE.read_text() == content:
+                return
+        except OSError:
+            pass
+
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        tmp_path = CACHED_IDS_FILE.with_name(CACHED_IDS_FILE.name + ".tmp")
+        tmp_path.write_text(content)
+        os.replace(tmp_path, CACHED_IDS_FILE)
+    except Exception:
+        LOGGER.exception("Failed to export cached game ids")

--- a/linux/raofflineproxy/knulli_service.py
+++ b/linux/raofflineproxy/knulli_service.py
@@ -1,0 +1,70 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+SERVICE_NAME = "raofflineproxy"
+USER_SERVICE_FILE = Path("/userdata/system/services/raofflineproxy")
+SYSTEM_SERVICE_FILES = (
+    Path("/usr/share/knulli/services/raofflineproxy"),
+    Path("/usr/share/batocera/services/raofflineproxy"),
+)
+
+
+def services_binary() -> str | None:
+    for name in ("knulli-services", "batocera-services"):
+        found = shutil.which(name)
+        if found:
+            return found
+    return None
+
+
+def service_mode_active() -> bool:
+    if services_binary() is None:
+        return False
+    if USER_SERVICE_FILE.exists():
+        return True
+    return any(path.exists() for path in SYSTEM_SERVICE_FILES)
+
+
+def _run(action: str) -> None:
+    binary = services_binary()
+    if binary is None:
+        raise RuntimeError("knulli-services not available")
+    subprocess.run(
+        [binary, action, SERVICE_NAME],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def service_autostart_enabled() -> bool:
+    binary = services_binary()
+    if binary is None:
+        return False
+    try:
+        output = subprocess.check_output([binary, "list"], text=True, timeout=30)
+    except (subprocess.SubprocessError, OSError):
+        return False
+    for line in output.splitlines():
+        parts = line.split(";")
+        if len(parts) == 2 and parts[0].strip() == SERVICE_NAME:
+            return parts[1].strip() == "*"
+    return False
+
+
+def enable_service_autostart() -> None:
+    _run("enable")
+
+
+def disable_service_autostart() -> None:
+    _run("disable")
+
+
+def start_service() -> None:
+    _run("start")
+
+
+def stop_service() -> None:
+    _run("stop")

--- a/linux/raofflineproxy/main.py
+++ b/linux/raofflineproxy/main.py
@@ -21,6 +21,7 @@ from .platform import (
     remove_boot_hook,
     resolve_rom_root,
 )
+from .es_export import CACHED_IDS_FILE, export_cached_game_ids
 from .batocera_conf import (
     patch_batocera_conf,
     revert_batocera_conf,
@@ -178,6 +179,8 @@ def main() -> None:
             "browser-list",
             "browser-list-fast",
             "cache-rom",
+            "cache-roms",
+            "export-cached-ids",
             "cache-folder-listing",
             "smart-cache-status",
             "run-smart-cache",
@@ -202,6 +205,11 @@ def main() -> None:
         "--path",
         dest="path",
         help="Filesystem path for browser and cache commands",
+    )
+    parser.add_argument(
+        "--paths-file",
+        dest="paths_file",
+        help="File containing one ROM path per line for cache-roms",
     )
     parser.add_argument(
         "--game-id",
@@ -490,6 +498,63 @@ def main() -> None:
                         ]
                     )
                 )
+            return
+
+        if args.command == "cache-roms":
+            if not args.paths_file:
+                raise ValueError("cache-roms requires --paths-file")
+
+            paths_file = Path(args.paths_file).expanduser()
+            if not paths_file.is_file():
+                raise ValueError(f"Invalid paths file: {paths_file}")
+
+            rom_paths = [
+                Path(line.strip()).expanduser()
+                for line in paths_file.read_text().splitlines()
+                if line.strip()
+            ]
+            if not rom_paths:
+                raise ValueError("cache-roms paths file is empty")
+
+            cached_count = 0
+            failed_count = 0
+            total = len(rom_paths)
+            storage = Storage()
+            try:
+                for index, rom_path in enumerate(rom_paths, start=1):
+                    label = rom_path.name
+                    if not rom_path.is_file():
+                        failed_count += 1
+                        print(f"FAIL {index}/{total} {label}: not found", flush=True)
+                        continue
+                    try:
+                        result = add_rom_to_cache(rom_path, storage, config_data)
+                    except Exception as error:
+                        failed_count += 1
+                        print(f"FAIL {index}/{total} {label}: {error}", flush=True)
+                        continue
+                    if result.success:
+                        cached_count += 1
+                        print(f"OK {index}/{total} {label}", flush=True)
+                    else:
+                        failed_count += 1
+                        print(
+                            f"FAIL {index}/{total} {label}: {result.message}",
+                            flush=True,
+                        )
+            finally:
+                storage.close()
+
+            print(f"DONE cached={cached_count} failed={failed_count}", flush=True)
+            return
+
+        if args.command == "export-cached-ids":
+            storage = Storage()
+            try:
+                export_cached_game_ids(storage)
+            finally:
+                storage.close()
+            print(str(CACHED_IDS_FILE))
             return
 
         if args.command == "cache-rom":

--- a/linux/raofflineproxy/menu_sdl.py
+++ b/linux/raofflineproxy/menu_sdl.py
@@ -42,6 +42,14 @@ from .rom_browser import (
     remove_cached_game,
 )
 from .service import service_status, start_service_process, stop_service_process
+from .knulli_service import (
+    disable_service_autostart,
+    enable_service_autostart,
+    service_autostart_enabled,
+    service_mode_active,
+    start_service,
+    stop_service,
+)
 from .smart_cache import (
     SMART_CACHE_LIMIT,
     load_content_history_paths,
@@ -488,20 +496,22 @@ class MenuSdlSession:
             labels.append("Cancel")
             return labels
 
-        toggle = "Stop proxy" if running else "Start proxy"
-        labels = [toggle]
         self.refresh_main_menu_state()
+        service_mode = getattr(self, "main_service_mode", False)
+        labels = []
+        if not service_mode:
+            labels.append("Stop proxy" if running else "Start proxy")
         if self.main_logged_in:
             labels.append(f"Cached games ({len(self.cached_games)})")
         if self.pending_awards:
             labels.append(f"Pending awards ({len(self.pending_awards)})")
-        if self.main_autostart_supported:
+        if self.main_autostart_supported and not service_mode:
             labels.append(
                 "Disable autostart"
                 if self.main_autostart_enabled
                 else "Enable autostart"
             )
-        if self.is_knulli_platform() or running_on_muos():
+        if (self.is_knulli_platform() and not service_mode) or running_on_muos():
             labels.append("Uninstall")
         if os.environ.get("RAOFFLINEPROXY_DEBUG"):
             labels.append("Key Logger")
@@ -623,7 +633,10 @@ class MenuSdlSession:
         connectivity_status = (
             "ONLINE" if bool(getattr(self, "main_online", False)) else "OFFLINE"
         )
-        status = f"PROXY: {proxy_status} {connectivity_status}"
+        if getattr(self, "main_service_mode", False):
+            status = f"KNULLI SERVICE: {proxy_status} {connectivity_status}"
+        else:
+            status = f"PROXY: {proxy_status} {connectivity_status}"
         if not logged_in:
             status += ", LOGIN REQUIRED"
         return status
@@ -788,16 +801,15 @@ class MenuSdlSession:
 
         labels = self.current_labels()
         selected_label = labels[self.selected_index] if labels else ""
-        running = self.proxy_running()
-        if self.selected_index == 0:
-            if running:
+        if selected_label.startswith(("Start proxy", "Stop proxy")):
+            if self.proxy_running():
                 self.stop_proxy()
             else:
                 self.start_proxy()
             return
 
         config_data = getattr(self, "config_data", {})
-        if selected_label in {"Enable autostart", "Disable autostart"}:
+        if selected_label.startswith(("Enable autostart", "Disable autostart")):
             self.toggle_autostart(config_data)
             return
 
@@ -1714,10 +1726,16 @@ class MenuSdlSession:
         self.main_running = self.read_proxy_running()
         self.main_online = online_check(self.config_data)
         self.main_logged_in = self.is_logged_in(self.config_data)
-        self.main_autostart_supported = autostart_supported(self.config_data)
-        self.main_autostart_enabled = (
-            self.main_autostart_supported and is_autostart_enabled(self.config_data)
-        )
+        self.main_service_mode = service_mode_active()
+        if self.main_service_mode:
+            self.main_autostart_supported = True
+            self.main_autostart_enabled = service_autostart_enabled()
+        else:
+            self.main_autostart_supported = autostart_supported(self.config_data)
+            self.main_autostart_enabled = (
+                self.main_autostart_supported
+                and is_autostart_enabled(self.config_data)
+            )
         if force:
             try:
                 update = update_status(self.update_platform())
@@ -1909,7 +1927,10 @@ class MenuSdlSession:
 
     def start_proxy(self) -> None:
         try:
-            start_proxy_inline()
+            if service_mode_active():
+                start_service()
+            else:
+                start_proxy_inline()
             self.refresh_main_menu_state(force=True)
             self.maybe_offer_smart_cache()
             if self.view != "smart_cache_prompt":
@@ -1919,7 +1940,11 @@ class MenuSdlSession:
 
     def stop_proxy(self) -> None:
         try:
-            stop_proxy_inline()
+            if service_mode_active():
+                stop_service()
+                stop_service_process()
+            else:
+                stop_proxy_inline()
             self.refresh_main_menu_state(force=True)
             self.message = ("Proxy stopped", time.monotonic() + 1.2)
         except Exception as exc:
@@ -1927,7 +1952,14 @@ class MenuSdlSession:
 
     def toggle_autostart(self, config_data: dict) -> None:
         try:
-            if is_autostart_enabled(config_data):
+            if service_mode_active():
+                if service_autostart_enabled():
+                    disable_service_autostart()
+                    self.message = ("Autostart disabled", time.monotonic() + 1.2)
+                else:
+                    enable_service_autostart()
+                    self.message = ("Autostart enabled", time.monotonic() + 1.2)
+            elif is_autostart_enabled(config_data):
                 disable_autostart(config_data)
                 self.message = ("Autostart disabled", time.monotonic() + 1.2)
             else:

--- a/linux/raofflineproxy/retroarch_cfg.py
+++ b/linux/raofflineproxy/retroarch_cfg.py
@@ -328,7 +328,11 @@ def _extract_config_value(content: str, key: str) -> str | None:
 
 
 def _upsert_config_value(content: str, key: str, value: str) -> str:
-    pattern = re.compile(rf"^(\s*{re.escape(key)}\s*=\s*).*$", re.MULTILINE)
+    # [ \t] instead of \s: \s matches newlines, so an empty existing value
+    # (e.g. "key = " written by configgen) would swallow the next line
+    pattern = re.compile(
+        rf"^([ \t]*{re.escape(key)}[ \t]*=[ \t]*).*$", re.MULTILINE
+    )
     if pattern.search(content):
         return pattern.sub(lambda match: f'{match.group(1)}"{value}"', content)
 
@@ -341,7 +345,7 @@ def _upsert_config_value(content: str, key: str, value: str) -> str:
 def _remove_orphan_boolean_lines(content: str) -> str:
     lines = content.splitlines()
     orphan_pattern = re.compile(
-        r'^[\x00-\x1f\x7f\s]*"(?:true|false)"[\x00-\x1f\x7f\s]*$'
+        r'^[\x00-\x1f\x7f\s]*"(?:true|false)?"[\x00-\x1f\x7f\s]*$'
     )
     kept = [line for line in lines if not orphan_pattern.fullmatch(line)]
     result = "\n".join(kept)

--- a/linux/raofflineproxy/storage.py
+++ b/linux/raofflineproxy/storage.py
@@ -5,7 +5,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from . import cache_keys
+from . import cache_keys, es_export
 from .config import DATABASE_FILE, ensure_config_dir
 
 try:
@@ -160,8 +160,13 @@ class Storage:
         now = cached_at or current_millis()
         if self._use_sqlite:
             self._upsert_cache_sqlite(cache_key, response_body, source_rom_path, now)
-            return
-        self._upsert_cache_json(cache_key, response_body, source_rom_path, now)
+        else:
+            self._upsert_cache_json(cache_key, response_body, source_rom_path, now)
+        self._after_cache_mutation(cache_key)
+
+    def _after_cache_mutation(self, *affected_keys: str | None) -> None:
+        if any(es_export.key_affects_cached_game_ids(key) for key in affected_keys):
+            es_export.export_cached_game_ids(self)
 
     def _upsert_cache_sqlite(
         self,
@@ -315,6 +320,7 @@ class Storage:
                     "DELETE FROM api_cache WHERE cacheKey LIKE ?", (f"{prefix}%",)
                 )
                 self._connection.commit()
+            self._after_cache_mutation(prefix)
             return
 
         with self._lock:
@@ -327,6 +333,7 @@ class Storage:
                     if not item["cacheKey"].startswith(prefix)
                 ]
                 self._write_json_state_unlocked()
+        self._after_cache_mutation(prefix)
 
     def rename_cache_key(self, old_key: str, new_key: str) -> None:
         if self._use_sqlite:
@@ -337,6 +344,7 @@ class Storage:
                     (new_key, old_key),
                 )
                 self._connection.commit()
+            self._after_cache_mutation(old_key, new_key)
             return
 
         with self._lock:
@@ -348,6 +356,7 @@ class Storage:
                         item["cacheKey"] = new_key
                         break
                 self._write_json_state_unlocked()
+        self._after_cache_mutation(old_key, new_key)
 
     def delete_cache(self, cache_key: str) -> None:
         if self._use_sqlite:
@@ -357,6 +366,7 @@ class Storage:
                     "DELETE FROM api_cache WHERE cacheKey = ?", (cache_key,)
                 )
                 self._connection.commit()
+            self._after_cache_mutation(cache_key)
             return
 
         with self._lock:
@@ -369,6 +379,7 @@ class Storage:
                     if item["cacheKey"] != cache_key
                 ]
                 self._write_json_state_unlocked()
+        self._after_cache_mutation(cache_key)
 
     def clear_cache(self) -> None:
         if self._use_sqlite:
@@ -385,6 +396,7 @@ class Storage:
                     """
                 )
                 self._connection.commit()
+            self._after_cache_mutation(None)
             return
 
         with self._lock:
@@ -405,6 +417,7 @@ class Storage:
                     )
                 ]
                 self._write_json_state_unlocked()
+        self._after_cache_mutation(None)
 
     def evict_cache_older_than(self, before: int) -> None:
         if self._use_sqlite:
@@ -420,6 +433,7 @@ class Storage:
                     (before, cache_keys.USER_AGENT),
                 )
                 self._connection.commit()
+            self._after_cache_mutation(None)
             return
 
         with self._lock:
@@ -434,6 +448,7 @@ class Storage:
                     or item["cacheKey"] == cache_keys.USER_AGENT
                 ]
                 self._write_json_state_unlocked()
+        self._after_cache_mutation(None)
 
     def get_pending_awards(self) -> list[dict]:
         if self._use_sqlite:

--- a/linux/tests/test_linux_batocera_conf.py
+++ b/linux/tests/test_linux_batocera_conf.py
@@ -109,3 +109,25 @@ class LinuxBatoceraConfTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class RevertNeverDisablesRetroachievementsTests(unittest.TestCase):
+    def test_revert_keeps_master_toggle_enabled_when_previous_was_absent(self) -> None:
+        content = (
+            "global.retroachievements=1\n"
+            'global.retroarch.cheevos_custom_host="127.0.0.1:8080"\n'
+        )
+        previous = {
+            batocera_conf.RETROACHIEVEMENTS_KEY: None,
+            batocera_conf.CHEEVOS_CUSTOM_HOST_KEY: None,
+        }
+        result = batocera_conf.build_reverted_batocera_conf(content, previous)
+        self.assertIn("global.retroachievements=1\n", result)
+        self.assertNotIn("cheevos_custom_host", result)
+
+    def test_revert_keeps_master_toggle_enabled_when_previous_was_disabled(self) -> None:
+        content = "global.retroachievements=1\n"
+        previous = {batocera_conf.RETROACHIEVEMENTS_KEY: "0"}
+        result = batocera_conf.build_reverted_batocera_conf(content, previous)
+        self.assertIn("global.retroachievements=1\n", result)
+        self.assertNotIn("global.retroachievements=0", result)

--- a/linux/tests/test_linux_es_export.py
+++ b/linux/tests/test_linux_es_export.py
@@ -1,0 +1,66 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from linux.raofflineproxy import es_export, storage
+
+
+class LinuxEsExportTests(unittest.TestCase):
+    def _read_ids(self, ids_file: Path) -> list[str]:
+        if not ids_file.exists():
+            return []
+        return [line for line in ids_file.read_text().splitlines() if line]
+
+    def test_cache_mutations_keep_cached_ids_file_in_sync(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            ids_file = root / "cached_game_ids.txt"
+            with (
+                mock.patch.object(es_export, "CACHED_IDS_FILE", ids_file),
+                mock.patch.object(es_export, "CONFIG_DIR", root),
+            ):
+                store = storage.Storage(database_path=root / "test.sqlite3")
+                try:
+                    store.upsert_cache("patch:10701:misantronic", "patch")
+                    self.assertEqual(self._read_ids(ids_file), ["10701"])
+
+                    store.upsert_cache(
+                        "achievementsets:testhash:misantronic",
+                        '{"GameId":515}',
+                    )
+                    self.assertEqual(self._read_ids(ids_file), ["515", "10701"])
+
+                    store.upsert_cache("ua::last", "RetroArch/1.20.0")
+                    self.assertEqual(self._read_ids(ids_file), ["515", "10701"])
+
+                    store.delete_cache_by_prefix("patch:10701:")
+                    self.assertEqual(self._read_ids(ids_file), ["515"])
+
+                    store.clear_cache()
+                    self.assertEqual(self._read_ids(ids_file), [])
+                finally:
+                    store.close()
+
+    def test_export_skips_rewrite_when_content_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            ids_file = root / "cached_game_ids.txt"
+            with (
+                mock.patch.object(es_export, "CACHED_IDS_FILE", ids_file),
+                mock.patch.object(es_export, "CONFIG_DIR", root),
+            ):
+                store = storage.Storage(database_path=root / "test.sqlite3")
+                try:
+                    store.upsert_cache("patch:10701:misantronic", "patch")
+                    first_stat = ids_file.stat()
+
+                    store.upsert_cache("patch:10701:misantronic", "patch-updated")
+                    self.assertEqual(ids_file.stat().st_mtime_ns, first_stat.st_mtime_ns)
+                    self.assertEqual(self._read_ids(ids_file), ["10701"])
+                finally:
+                    store.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/linux/tests/test_linux_knulli_service_mode.py
+++ b/linux/tests/test_linux_knulli_service_mode.py
@@ -1,0 +1,154 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from linux.raofflineproxy import knulli_service, menu_sdl
+
+
+class KnulliServiceModeDetectionTests(unittest.TestCase):
+    def test_inactive_without_services_binary(self) -> None:
+        with mock.patch.object(knulli_service.shutil, "which", return_value=None):
+            self.assertFalse(knulli_service.service_mode_active())
+
+    def test_inactive_with_binary_but_no_service_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            missing = Path(temp_dir) / "raofflineproxy"
+            with (
+                mock.patch.object(
+                    knulli_service.shutil, "which", return_value="/usr/bin/knulli-services"
+                ),
+                mock.patch.object(knulli_service, "USER_SERVICE_FILE", missing),
+                mock.patch.object(knulli_service, "SYSTEM_SERVICE_FILES", (missing,)),
+            ):
+                self.assertFalse(knulli_service.service_mode_active())
+
+    def test_active_with_binary_and_service_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            service_file = Path(temp_dir) / "raofflineproxy"
+            service_file.write_text("#!/bin/bash\n")
+            with (
+                mock.patch.object(
+                    knulli_service.shutil, "which", return_value="/usr/bin/knulli-services"
+                ),
+                mock.patch.object(knulli_service, "USER_SERVICE_FILE", service_file),
+                mock.patch.object(knulli_service, "SYSTEM_SERVICE_FILES", ()),
+            ):
+                self.assertTrue(knulli_service.service_mode_active())
+
+
+class KnulliServiceModeMenuTests(unittest.TestCase):
+    def _make_main_session(self, service_mode: bool) -> menu_sdl.MenuSdlSession:
+        session = menu_sdl.MenuSdlSession.__new__(menu_sdl.MenuSdlSession)
+        session.view = "main"
+        session.cached_games = []
+        session.pending_awards = []
+        session.main_logged_in = True
+        session.main_running = False
+        session.main_online = True
+        session.main_service_mode = service_mode
+        session.main_autostart_supported = not service_mode or True
+        session.main_autostart_enabled = False
+        return session
+
+    def _labels(self, session: menu_sdl.MenuSdlSession) -> list[str]:
+        with (
+            mock.patch.object(
+                menu_sdl.MenuSdlSession, "refresh_main_menu_state", lambda self, force=False: None
+            ),
+            mock.patch.object(
+                menu_sdl.MenuSdlSession, "is_knulli_platform", lambda self: True
+            ),
+            mock.patch.object(menu_sdl, "running_on_muos", lambda: False),
+        ):
+            return menu_sdl.MenuSdlSession.labels(session, False)
+
+    def test_legacy_mode_keeps_start_autostart_and_uninstall(self) -> None:
+        session = self._make_main_session(service_mode=False)
+        session.main_autostart_supported = True
+        labels = self._labels(session)
+        self.assertIn("Start proxy", labels)
+        self.assertIn("Enable autostart", labels)
+        self.assertIn("Uninstall", labels)
+
+    def test_service_mode_hides_lifecycle_and_uninstall_entries(self) -> None:
+        session = self._make_main_session(service_mode=True)
+        labels = self._labels(session)
+        self.assertNotIn("Start proxy", labels)
+        self.assertNotIn("Stop proxy", labels)
+        self.assertNotIn("Enable autostart", labels)
+        self.assertNotIn("Disable autostart", labels)
+        self.assertNotIn("Uninstall", labels)
+        self.assertIn("Exit Menu", labels)
+
+    def test_legacy_status_text_unchanged(self) -> None:
+        session = self._make_main_session(service_mode=False)
+        with mock.patch.object(
+            menu_sdl.MenuSdlSession, "refresh_main_menu_state", lambda self, force=False: None
+        ):
+            status = menu_sdl.MenuSdlSession.status_text(session, running=True)
+        self.assertEqual(status, "PROXY: RUNNING ONLINE")
+
+    def test_service_status_text_mentions_service(self) -> None:
+        session = self._make_main_session(service_mode=True)
+        with mock.patch.object(
+            menu_sdl.MenuSdlSession, "refresh_main_menu_state", lambda self, force=False: None
+        ):
+            status = menu_sdl.MenuSdlSession.status_text(session, running=True)
+        self.assertEqual(status, "KNULLI SERVICE: RUNNING ONLINE")
+
+    def test_legacy_start_proxy_uses_inline_path(self) -> None:
+        session = menu_sdl.MenuSdlSession.__new__(menu_sdl.MenuSdlSession)
+        session.view = "main"
+        calls = []
+        with (
+            mock.patch.object(menu_sdl, "service_mode_active", return_value=False),
+            mock.patch.object(
+                menu_sdl, "start_proxy_inline", lambda: calls.append("inline")
+            ),
+            mock.patch.object(
+                menu_sdl, "start_service", lambda: calls.append("service")
+            ),
+            mock.patch.object(
+                menu_sdl.MenuSdlSession,
+                "refresh_main_menu_state",
+                lambda self, force=False: None,
+            ),
+            mock.patch.object(
+                menu_sdl.MenuSdlSession,
+                "maybe_offer_smart_cache",
+                lambda self: None,
+            ),
+        ):
+            menu_sdl.MenuSdlSession.start_proxy(session)
+        self.assertEqual(calls, ["inline"])
+
+    def test_service_start_proxy_uses_service(self) -> None:
+        session = menu_sdl.MenuSdlSession.__new__(menu_sdl.MenuSdlSession)
+        session.view = "main"
+        calls = []
+        with (
+            mock.patch.object(menu_sdl, "service_mode_active", return_value=True),
+            mock.patch.object(
+                menu_sdl, "start_proxy_inline", lambda: calls.append("inline")
+            ),
+            mock.patch.object(
+                menu_sdl, "start_service", lambda: calls.append("service")
+            ),
+            mock.patch.object(
+                menu_sdl.MenuSdlSession,
+                "refresh_main_menu_state",
+                lambda self, force=False: None,
+            ),
+            mock.patch.object(
+                menu_sdl.MenuSdlSession,
+                "maybe_offer_smart_cache",
+                lambda self: None,
+            ),
+        ):
+            menu_sdl.MenuSdlSession.start_proxy(session)
+        self.assertEqual(calls, ["service"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/linux/tests/test_linux_retroarch_cfg.py
+++ b/linux/tests/test_linux_retroarch_cfg.py
@@ -104,3 +104,28 @@ class LinuxRetroarchCfgTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class UpsertEmptyValueRegressionTests(unittest.TestCase):
+    def test_upsert_on_empty_unquoted_value_does_not_eat_next_line(self) -> None:
+        content = (
+            "menu_battery_level_enable = false\n"
+            "cheevos_custom_host = \n"
+            "input_libretro_device_p4 = 1\n"
+        )
+        result = retroarch_cfg._upsert_config_value(
+            content, "cheevos_custom_host", "127.0.0.1:8080"
+        )
+        self.assertIn('cheevos_custom_host = "127.0.0.1:8080"', result)
+        self.assertIn("input_libretro_device_p4 = 1", result)
+        self.assertNotIn('\n""\n', result)
+
+    def test_sanitizer_removes_orphan_empty_quote_lines(self) -> None:
+        content = (
+            "cheevos_custom_host = \n"
+            '""\n'
+            "input_libretro_device_p4 = 1\n"
+        )
+        result = retroarch_cfg._remove_orphan_boolean_lines(content)
+        self.assertNotIn('""', result)
+        self.assertIn("input_libretro_device_p4 = 1", result)


### PR DESCRIPTION
Linux-side changes for the Knulli native integration (companion to knulli-cfw/knulli-linux#94 and knulli-cfw/batocera-emulationstation#126).

### Changes
- `es_export.py`: export cached RA game ids to `cached_game_ids.txt` on every cache mutation (hooked centrally in `Storage`); read by the EmulationStation integration for the offline icons
- New CLI: `cache-roms --paths-file` (batch caching with progress output for the ES gamelist action) and `export-cached-ids`
- `knulli_service.py` + menu: when the Knulli service is installed, the SDL menu hides Start/Stop, autostart and Uninstall (single control point: ES Services toggle) and shows "KNULLI SERVICE" status; unchanged behavior on muOS/Onion or without the service
- `linux/knulli/integration/`: dev kit used for on-device testing (service file, configgen patcher with revert, ES deploy scripts)

### Fixes
- `retroarch_cfg.py`: upsert regex could swallow the following config line when a value was empty (`\s*` matches newlines) — corrupted retroarch.cfg; orphan `""` lines are now also self-healed
- `batocera_conf.py`: revert no longer touches `global.retroachievements` — the proxy may enable the master toggle but never disables it

Tested on RG40XX-H (h700); tag `knulli-native-preview-1` was built from this branch.
