### PR TITLE
Document ROCKNIX Linux target

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ RAOfflineProxy runs a tiny local proxy on your device. It sits between supported
 ## Supported Platforms
 
 - **Android**: RetroArch, Dolphin, PPSSPP, ARMSX2, ARMSX2 Refresh
-- **Linux**: KNULLI, Onion, muOS
+- **Linux**: KNULLI, Onion, muOS, ROCKNIX
 
 ## Current Releases
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 RAOfflineProxy is a local proxy that lets you earn **casual RetroAchievements** without an internet connection.
 
-> **Current release stage: `v1.5.5-alpha1`.** This is a public prerelease and has not gone through formal QA.
+> **Current release stage: `v1.6.0-alpha1`.** This is a public prerelease and has not gone through formal QA.
 
 RAOfflineProxy runs a tiny local proxy on your device. It sits between supported emulators and the RetroAchievements server, saving game and achievement data for offline use and queuing any achievements you unlock while offline. When you reconnect, queued awards are automatically sent to RetroAchievements.
 
@@ -18,8 +18,8 @@ RAOfflineProxy runs a tiny local proxy on your device. It sits between supported
 
 ## Current Releases
 
-- **Android**: [`v1.5.5-alpha1`](https://github.com/misantronic/RAOfflineProxy/releases/tag/v1.5.5-alpha1)
-- **Linux**: [`v1.5.5-alpha1`](https://github.com/misantronic/RAOfflineProxy/releases/tag/v1.5.5-alpha1)
+- **Android**: [`v1.6.0-alpha1`](https://github.com/misantronic/RAOfflineProxy/releases/tag/v1.6.0-alpha1)
+- **Linux**: [`v1.6.0-alpha1`](https://github.com/misantronic/RAOfflineProxy/releases/tag/v1.6.0-alpha1)
 
 ## Obtainium
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = "com.raofflineproxy"
         minSdk = 26
         targetSdk = 36
-        versionCode = 21
-        versionName = "1.5.5-alpha1"
+        versionCode = 22
+        versionName = "1.6.0-alpha1"
     }
 
     signingConfigs {

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -31,7 +31,7 @@
 }
 
 .VPNavBarTitle .title::after {
-  content: 'v1.5.5-alpha1';
+  content: 'v1.6.0-alpha1';
   grid-column: 2;
   grid-row: 2;
   margin-top: -1.4rem;

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,6 +85,10 @@ features:
           <img src="/muos.png" alt="muOS logo">
           <span>muOS</span>
         </div>
+        <div class="supported-platforms__item">
+          <img class="supported-platforms__logo--rounded" src="/rocknix.png" alt="ROCKNIX logo">
+          <span>ROCKNIX</span>
+        </div>
       </div>
     </div>
   </div>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation & Setup (Android)
 
-> You are installing the current alpha build: `v1.5.5-alpha1`.
+> You are installing the current alpha build: `v1.6.0-alpha1`.
 
 ## Prerequisites
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -4,7 +4,7 @@
 
 ## What is RAOfflineProxy?
 
-RAOfflineProxy is a local proxy that acts between supported emulators and [RetroAchievements](https://retroachievements.org/) (RA). It currently supports RetroArch, Dolphin, PPSSPP, ARMSX2, and ARMSX2 Refresh on **Android**, and **KNULLI**, **Onion**, and **muOS** (all alpha) for Linux.
+RAOfflineProxy is a local proxy that acts between supported emulators and [RetroAchievements](https://retroachievements.org/) (RA). It currently supports RetroArch, Dolphin, PPSSPP, ARMSX2, and ARMSX2 Refresh on **Android**, and **KNULLI**, **Onion**, **muOS**, and **ROCKNIX** (all alpha) for Linux.
 
 Their achievement systems talk directly to RetroAchievements over the internet. This works great online, but the moment your connection drops, achievements stop unlocking and games may fail to load their achievement lists at all.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-> Current release stage: `v1.5.5-alpha1`. This is a public prerelease and has not gone through formal QA.
+> Current release stage: `v1.6.0-alpha1`. This is a public prerelease and has not gone through formal QA.
 
 ## What is RAOfflineProxy?
 

--- a/docs/linux-support/cfg-patching.md
+++ b/docs/linux-support/cfg-patching.md
@@ -32,6 +32,12 @@ muOS RetroArch also loads a separate cheevos appendconfig, which stores your Ret
 
 RAOfflineProxy keeps both files in sync when patching and reverting.
 
+== ROCKNIX
+
+```text
+/storage/.config/retroarch/retroarch.cfg
+```
+
 :::
 
 ## What Gets Patched

--- a/docs/linux-support/cfg-patching.md
+++ b/docs/linux-support/cfg-patching.md
@@ -38,15 +38,26 @@ RAOfflineProxy keeps both files in sync when patching and reverting.
 /storage/.config/retroarch/retroarch.cfg
 ```
 
+ROCKNIX also ships standalone PPSSPP with its own RetroAchievements support. When `ppsspp.ini` exists, RAOfflineProxy patches it too:
+
+```text
+/storage/.config/ppsspp/PSP/SYSTEM/ppsspp.ini
+```
+
 :::
 
 ## What Gets Patched
 
-While the proxy is active, `RAOfflineProxy` patches:
+While the proxy is active, `RAOfflineProxy` patches RetroArch:
 
 - `cheevos_enable = "true"`
 - `cheevos_custom_host = "<proxy_host>:<proxy_port>"`
 - `cheevos_hardcore_mode_enable = "false"`
+
+On ROCKNIX, standalone PPSSPP is patched the same way:
+
+- `AchievementsHost = <proxy_host>:<proxy_port>`
+- `AchievementsChallengeMode = False`
 
 Hardcore mode is not supported.
 

--- a/docs/linux-support/index.md
+++ b/docs/linux-support/index.md
@@ -11,14 +11,14 @@ The Linux version is for handheld Linux devices where you want the same basic of
 - Keep earning casual achievements while offline
 - Let queued awards sync later when you reconnect
 
-Use the `KNULLI`, `Onion`, and `muOS` tabs throughout the Linux section to switch target-specific instructions.
+Use the `KNULLI`, `Onion`, `muOS`, and `ROCKNIX` tabs throughout the Linux section to switch target-specific instructions.
 
 ## Supported Targets
 
 - KNULLI (alpha)
 - Onion (alpha)
 - muOS (alpha)
-- ROCKNIX (planned)
+- ROCKNIX (alpha)
 
 ## Specifics
 
@@ -53,10 +53,20 @@ Current rough edges:
 - The bundled runtime (including `pygame`, which stock muOS does not ship) is larger than ideal and takes time to copy to SD storage
 - Patching has to keep both `retroarch.cfg` and the `retroarch.cheevos.cfg` appendconfig in sync
 
+== ROCKNIX
+
+It is currently compatible with [ROCKNIX 20260701](https://github.com/ROCKNIX/distribution/releases/tag/20260701) or newer.
+
+The ROCKNIX target ships as a self-extracting installer and runs the same SDL menu used on the other Linux targets. The app installs under `/storage/.local/share/raofflineproxy` and appears in the **Tools** menu.
+
+Current rough edges:
+
+- The bundled runtime (including `pygame`, which stock ROCKNIX does not ship) is larger than ideal
+
 :::
 
 ## Important Notes
 
 - Linux support is currently in alpha and should still be treated as a prerelease feature.
 - Linux install, startup, and UI behavior can vary a lot by firmware and frontend.
-- Always check the correct tab for your device instead of assuming KNULLI, Onion, and muOS behave the same way.
+- Always check the correct tab for your device instead of assuming KNULLI, Onion, muOS, and ROCKNIX behave the same way.

--- a/docs/linux-support/index.md
+++ b/docs/linux-support/index.md
@@ -59,6 +59,8 @@ It is currently compatible with [ROCKNIX 20260701](https://github.com/ROCKNIX/di
 
 The ROCKNIX target ships as a self-extracting installer and runs the same SDL menu used on the other Linux targets. The app installs under `/storage/.local/share/raofflineproxy` and appears in the **Tools** menu.
 
+Both RetroArch and standalone PPSSPP are supported on ROCKNIX. Starting the proxy patches both `retroarch.cfg` and, when present, `ppsspp.ini`.
+
 Current rough edges:
 
 - The bundled runtime (including `pygame`, which stock ROCKNIX does not ship) is larger than ideal

--- a/docs/linux-support/installation.md
+++ b/docs/linux-support/installation.md
@@ -32,11 +32,13 @@ Before using `RAOfflineProxy` on Linux:
 
 - Enter your RetroAchievements account details<br>
   > Game Settings -> Retroachievement settings
+- If you also use standalone PPSSPP, log in separately inside PPSSPP<br>
+  > Settings -> Tools -> Achievement Settings
 
 :::
 
-::: warning RetroArch config is patched automatically
-RAOfflineProxy patches the RetroArch config it needs in order to redirect RetroAchievements traffic through the local proxy. For target-specific details, see [Emulator Patching](/linux-support/cfg-patching).
+::: warning Emulator configs are patched automatically
+RAOfflineProxy patches the emulator configs it needs in order to redirect RetroAchievements traffic through the local proxy (RetroArch everywhere, plus standalone PPSSPP on ROCKNIX). For target-specific details, see [Emulator Patching](/linux-support/cfg-patching).
 :::
 
 ## Setup

--- a/docs/linux-support/installation.md
+++ b/docs/linux-support/installation.md
@@ -10,7 +10,8 @@ Before using `RAOfflineProxy` on Linux:
 
 == KNULLI
 
-- Enter your RetroAchievements account details in RetroArch
+- Enter your RetroAchievements account details<br>
+  > Game Settings -> Retroachievement settings
 
 == Onion
 
@@ -26,6 +27,11 @@ Before using `RAOfflineProxy` on Linux:
 - Enter your RetroAchievements account details in RetroArch<br>
   > muOS stores these credentials in the `retroarch.cheevos.cfg` appendconfig, which RAOfflineProxy reads automatically.
 - Make sure the system clock is correct so award timestamps are accurate
+
+== ROCKNIX
+
+- Enter your RetroAchievements account details<br>
+  > Game Settings -> Retroachievement settings
 
 :::
 
@@ -49,11 +55,10 @@ RAOfflineProxy patches the RetroArch config it needs in order to redirect RetroA
 ```
 
 3. Refresh or update gamelists so **RAOfflineProxy Install** appears in the **Tools** menu
-4. Launch **RAOfflineProxy Install** from **Tools**
-5. Refresh or update gamelists again so the main **RAOfflineProxy** entry appears
-6. Launch **RAOfflineProxy** from the **Tools** menu
-7. Start the proxy while online
-8. Cache games either from **Cached Games** then **Add ROM** or by launching them once in RetroArch
+4. Launch **RAOfflineProxy Install** from **Tools** — gamelists are refreshed automatically once it finishes, so the main **RAOfflineProxy** entry appears without a manual refresh
+5. Launch **RAOfflineProxy** from the **Tools** menu
+6. Start the proxy while online
+7. Cache games either from **Cached Games** then **Add ROM** or by launching them once in RetroArch
 
 == Onion
 
@@ -91,6 +96,30 @@ RAOfflineProxy patches the RetroArch config it needs in order to redirect RetroA
 
 5. Start the proxy while online
 6. Launch a game once so its data is cached
+
+== ROCKNIX
+
+> ROCKNIX support is currently in alpha.
+
+1. Download the latest `RAOfflineProxy-Rocknix-*-Install.sh` from [GitHub Releases](https://github.com/misantronic/RAOfflineProxy/releases)
+2. Copy the installer into:
+
+```text
+/storage/.config/modules
+```
+
+3. Refresh or update gamelists so the installer appears in the **Tools** menu
+4. Launch the installer from **Tools** — it installs the app, removes itself, and refreshes gamelists automatically so the main **RAOfflineProxy** entry appears without a manual refresh
+
+   The app payload is installed under:
+
+```text
+/storage/.local/share/raofflineproxy
+```
+
+5. Launch **RAOfflineProxy** from the **Tools** menu
+6. Start the proxy while online
+7. Cache games either from **Cached Games** then **Add ROM** or by launching them once in RetroArch
 
 :::
 

--- a/docs/linux-support/settings.md
+++ b/docs/linux-support/settings.md
@@ -50,6 +50,18 @@ It also enables muOS user init so that script runs on boot:
 /opt/muos/config/settings/advanced/user_init
 ```
 
+== ROCKNIX
+
+ROCKNIX autostart is available from the app menu.
+
+If you enable it, RAOfflineProxy installs a boot hook under ROCKNIX's autostart directory:
+
+```text
+/storage/.config/autostart/raofflineproxy.sh
+```
+
+ROCKNIX runs every script in that directory on boot. The hook re-adds the **Tools** menu entry (ROCKNIX rebuilds that menu from a read-only source on each boot) and, when autostart is enabled, starts the proxy.
+
 :::
 
 ## Start / Stop Behavior

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -24,5 +24,5 @@ This page tracks which emulators and Linux handheld platforms `RAOfflineProxy` c
 |                 <img class="platforms-table__logo" src="/knulli.png" alt="KNULLI logo">                  | **KNULLI** (RetroArch) | ✅ Supported |
 |                  <img class="platforms-table__logo" src="/onion.svg" alt="Onion logo">                   | **Onion** (RetroArch)  | ✅ Supported |
 |                   <img class="platforms-table__logo" src="/muos.png" alt="muOS logo">                    | **muOS** (RetroArch)   | ✅ Supported |
-| <img class="platforms-table__logo platforms-table__logo--rounded" src="/rocknix.png" alt="ROCKNIX logo"> | **ROCKNIX**            | 🔜 Planned   |
+| <img class="platforms-table__logo platforms-table__logo--rounded" src="/rocknix.png" alt="ROCKNIX logo"> | **ROCKNIX** (RetroArch) | ✅ Supported |
 | <img class="platforms-table__logo platforms-table__logo--rounded" src="/darkos.png" alt="dArkOS logo"> | **dArkOS**            | 🔜 Planned, [pending release](https://github.com/misantronic/RAOfflineProxy/pull/47)   |

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -24,5 +24,5 @@ This page tracks which emulators and Linux handheld platforms `RAOfflineProxy` c
 |                 <img class="platforms-table__logo" src="/knulli.png" alt="KNULLI logo">                  | **KNULLI** (RetroArch) | ✅ Supported |
 |                  <img class="platforms-table__logo" src="/onion.svg" alt="Onion logo">                   | **Onion** (RetroArch)  | ✅ Supported |
 |                   <img class="platforms-table__logo" src="/muos.png" alt="muOS logo">                    | **muOS** (RetroArch)   | ✅ Supported |
-| <img class="platforms-table__logo platforms-table__logo--rounded" src="/rocknix.png" alt="ROCKNIX logo"> | **ROCKNIX** (RetroArch) | ✅ Supported |
+| <img class="platforms-table__logo platforms-table__logo--rounded" src="/rocknix.png" alt="ROCKNIX logo"> | **ROCKNIX** (RetroArch, PPSSPP) | ✅ Supported |
 | <img class="platforms-table__logo platforms-table__logo--rounded" src="/darkos.png" alt="dArkOS logo"> | **dArkOS**            | 🔜 Planned, [pending release](https://github.com/misantronic/RAOfflineProxy/pull/47)   |

--- a/linux/knulli/build_bundle.sh
+++ b/linux/knulli/build_bundle.sh
@@ -7,7 +7,7 @@ DIST_DIR="${SCRIPT_DIR}/dist"
 BUILD_DIR="${DIST_DIR}/raofflineproxy-knulli-bundle"
 APP_DIR="${BUILD_DIR}/app"
 LIB_DIR="${BUILD_DIR}/lib"
-INSTALLER_PATH="${DIST_DIR}/RAOfflineProxy-Knulli-v1.5.5-alpha1-Install.sh"
+INSTALLER_PATH="${DIST_DIR}/RAOfflineProxy-Knulli-v1.6.0-alpha1-Install.sh"
 TEMP_TARBALL="${DIST_DIR}/.raofflineproxy-knulli-bundle.tar.gz"
 
 TARGET="aarch64-linux-gnu.2.17" OUT_DIR="${SCRIPT_DIR}/native" \

--- a/linux/muos/build_bundle.sh
+++ b/linux/muos/build_bundle.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LINUX_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-VERSION="${RAOFFLINEPROXY_APP_VERSION:-1.5.5-alpha1}"
+VERSION="${RAOFFLINEPROXY_APP_VERSION:-1.6.0-alpha1}"
 DIST_DIR="${SCRIPT_DIR}/dist/RAOfflineProxy"
 APP_DIR="${DIST_DIR}/app"
 LIB_DIR="${DIST_DIR}/lib"

--- a/linux/onion/app/RAOfflineProxy/common.sh
+++ b/linux/onion/app/RAOfflineProxy/common.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 APP_DIR=/mnt/SDCARD/App/RAOfflineProxy
-APP_VERSION=v1.5.5-alpha1
+APP_VERSION=v1.6.0-alpha1
 APP_MAX_CACHED_GAMES=100
 APP_DATA_DIR="$APP_DIR/data"
 APP_RUNTIME_DIR="$APP_DIR/runtime"

--- a/linux/onion/build_bundle.sh
+++ b/linux/onion/build_bundle.sh
@@ -10,7 +10,7 @@ LIB_DIR="${APP_DIR}/lib"
 RUNTIME_CACHE_DIR="${SCRIPT_DIR}/runtime-cache"
 RUNTIME_ARCHIVE_NAME="cpython-3.10.20+20260510-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz"
 RUNTIME_ARCHIVE_PATH="${RUNTIME_CACHE_DIR}/${RUNTIME_ARCHIVE_NAME}"
-ZIP_NAME="RAOfflineProxy-Onion-v1.5.5-alpha1.zip"
+ZIP_NAME="RAOfflineProxy-Onion-v1.6.0-alpha1.zip"
 
 TARGET="arm-linux-gnueabihf.2.17" OUT_DIR="${SCRIPT_DIR}/native" \
   "${LINUX_DIR}/build_rchash.sh"
@@ -57,7 +57,7 @@ import zipfile
 
 dist_dir = Path(r"/Users/dschkalee/src/RAOfflineProxy/linux/onion/dist")
 build_dir = dist_dir / "raofflineproxy-onion-app"
-zip_path = dist_dir / "RAOfflineProxy-Onion-v1.5.5-alpha1.zip"
+zip_path = dist_dir / "RAOfflineProxy-Onion-v1.6.0-alpha1.zip"
 
 with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
     for path in sorted(build_dir.rglob("*")):

--- a/linux/raofflineproxy/config.py
+++ b/linux/raofflineproxy/config.py
@@ -52,9 +52,9 @@ def resolve_config_dir() -> Path:
 
 RA_HOST = "https://retroachievements.org"
 RA_MEDIA_HOST = "https://media.retroachievements.org"
-PROXY_UA_TAG = "RAOfflineProxy/Linux/1.5.5-alpha1"
+PROXY_UA_TAG = "RAOfflineProxy/Linux/1.6.0-alpha1"
 FALLBACK_USER_AGENT = "RetroArch/1.21.0 (Linux)"
-APP_VERSION = os.environ.get("RAOFFLINEPROXY_APP_VERSION") or "1.5.5-alpha1"
+APP_VERSION = os.environ.get("RAOFFLINEPROXY_APP_VERSION") or "1.6.0-alpha1"
 
 DEFAULT_PROXY_PORT = 8080
 MIN_PROXY_PORT = 1024

--- a/linux/rocknix/build_bundle.sh
+++ b/linux/rocknix/build_bundle.sh
@@ -7,7 +7,7 @@ DIST_DIR="${SCRIPT_DIR}/dist"
 BUILD_DIR="${DIST_DIR}/raofflineproxy-rocknix-bundle"
 APP_DIR="${BUILD_DIR}/app"
 LIB_DIR="${BUILD_DIR}/lib"
-VERSION="${RAOFFLINEPROXY_APP_VERSION:-1.5.5-alpha1}"
+VERSION="${RAOFFLINEPROXY_APP_VERSION:-1.6.0-alpha1}"
 INSTALLER_PATH="${DIST_DIR}/RAOfflineProxy-Rocknix-v${VERSION}-Install.sh"
 TEMP_TARBALL="${DIST_DIR}/.raofflineproxy-rocknix-bundle.tar.gz"
 


### PR DESCRIPTION
## Summary
- Add ROCKNIX to the supported-platforms list on the index page and platforms table
- Add ROCKNIX tabs (prerequisites, setup, RetroArch config path, autostart) across the Linux support guide, matching the KNULLI/Onion/muOS pattern
- Note automatic gamelist refresh after install/uninstall on the ES-based targets (KNULLI, ROCKNIX)

## Test plan
- [x] `npm run build` in `docs/` succeeds with no errors
- [x] Manually reviewed each tabbed page renders the new ROCKNIX tab correctly