### PR TITLE
Rename dArkOS proxy process to survive game-end killall python3 cleanup

### DIFF
--- a/linux/raofflineproxy/service.py
+++ b/linux/raofflineproxy/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ctypes
 import logging
 import os
 from pathlib import Path
@@ -23,6 +24,20 @@ SERVICE_COMMAND_MARKERS = [
     "-m raofflineproxy.main run-service",
     "-m linux.raofflineproxy.main run-service",
 ]
+
+PR_SET_NAME = 15
+
+
+def _rename_process(name: str) -> None:
+    """Rename this process's kernel-visible name (/proc/pid/comm) away from
+    "python3" so blunt cleanup commands some launchers run on game exit
+    (e.g. dArkOS's game-end hook runs `killall python3`, which matches by
+    comm, not argv/cgroup) don't kill the service by accident."""
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        libc.prctl(PR_SET_NAME, name.encode("utf-8"), 0, 0, 0)
+    except (OSError, AttributeError):
+        pass
 
 
 def process_is_running(pid: int) -> bool:
@@ -304,6 +319,8 @@ def service_status() -> dict:
 
 
 def run_service_foreground(config_data: dict) -> None:
+    _rename_process("raofflineproxy")
+
     stop_requested = False
 
     def handle_signal(_signum: int, _frame: object) -> None:

--- a/linux/raofflineproxy/service.py
+++ b/linux/raofflineproxy/service.py
@@ -36,8 +36,12 @@ def _rename_process(name: str) -> None:
     try:
         libc = ctypes.CDLL(None, use_errno=True)
         libc.prctl(PR_SET_NAME, name.encode("utf-8"), 0, 0, 0)
-    except (OSError, AttributeError):
-        pass
+    except (OSError, AttributeError) as exc:
+        logging.getLogger("raofflineproxy").warning(
+            "Failed to rename process via prctl; comm name stays %r (%s)",
+            name,
+            exc,
+        )
 
 
 def process_is_running(pid: int) -> bool:


### PR DESCRIPTION
## Summary
- dArkOS's EmulationStation game-end hook runs `sudo killall python3` on every game exit (confirmed via journalctl), which matches the proxy service by kernel process name since it runs as `python3 -m raofflineproxy.main run-service`.
- Rename the process via `prctl(PR_SET_NAME, ...)` so it's no longer swept up by that cleanup command. Service discovery (`discover_service_pids()`) is unaffected since it matches on `/proc/pid/cmdline`, not `comm`.

## Test plan
- [x] Confirmed on-device: `ps -o pid,comm,args` shows `comm=raofflineproxy` after the fix (previously `python3`)
- [x] Confirmed the proxy process survives launching and exiting a game on dArkOS, where it previously got killed every time
