### PR TITLE
Bump @aws-sdk/client-s3 and @aws-sdk/client-ses to 3.1099.0 in /lambda

### DIFF
--- a/lambda/package-lock.json
+++ b/lambda/package-lock.json
@@ -13,7 +13,7 @@
                 "raop-support-payment"
             ],
             "devDependencies": {
-                "@aws-sdk/client-s3": "^3.1092.0",
+                "@aws-sdk/client-s3": "^3.1099.0",
                 "@aws-sdk/s3-request-presigner": "^3.1099.0",
                 "@types/node": "^22.13.13",
                 "archiver": "^7.0.1",
@@ -22,14 +22,14 @@
             }
         },
         "node_modules/@aws-sdk/checksums": {
-            "version": "3.1000.19",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.19.tgz",
-            "integrity": "sha512-Hc4N100RdkuWshKBnhPzmpdftfi9mCLz+OHFELHM1QIgMH4QRUUWyWgfiebta/YX2Bd62wTcm3EqAP8TeXv0gA==",
+            "version": "3.1000.24",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.24.tgz",
+            "integrity": "sha512-7TWLjypP8kk3savsDBRuhZJx7mBuFFA2136BQhwwLllsAnO4Tmq/p+SXZaNxbuulkzUFz3BZzj0bb4YzexZcNQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.976.0",
+                "@aws-sdk/core": "^3.977.4",
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/core": "^3.29.4",
+                "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -38,20 +38,20 @@
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.1092.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1092.0.tgz",
-            "integrity": "sha512-NfcptdANQM1IgUT8QITKBN+PZPjshm5FyLKKjotEwscsDQGik4iDdLgwFYJSTlGoREv26Tf97WHpL7IZ3HF9nA==",
+            "version": "3.1101.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1101.0.tgz",
+            "integrity": "sha512-16EFb1aTEBgPcfUAWAjjlB57IZCyn7B3rlfT+xqE7M6WoH8AMMU3vFZO0UOitwh/xvvzVx73YED1/n0PU4qBMw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/checksums": "^3.1000.19",
-                "@aws-sdk/core": "^3.976.0",
-                "@aws-sdk/credential-provider-node": "^3.972.71",
-                "@aws-sdk/middleware-sdk-s3": "^3.972.65",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+                "@aws-sdk/checksums": "^3.1000.24",
+                "@aws-sdk/core": "^3.977.4",
+                "@aws-sdk/credential-provider-node": "^3.972.76",
+                "@aws-sdk/middleware-sdk-s3": "^3.972.70",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.43",
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/core": "^3.29.4",
-                "@smithy/fetch-http-handler": "^5.6.6",
-                "@smithy/node-http-handler": "^4.9.6",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -60,17 +60,17 @@
             }
         },
         "node_modules/@aws-sdk/client-ses": {
-            "version": "3.1095.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.1095.0.tgz",
-            "integrity": "sha512-SHggF3KqHggbz8U1EAEIxl/+K5YTpt6E6O0SaXJLk8QV/ph6NRREFQXcWIe9R0BBEb0sTEM/RCj6yjlDzcEG2g==",
+            "version": "3.1101.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.1101.0.tgz",
+            "integrity": "sha512-HYAcOcmgP7yNolZc+1cHTPBYmaPEjxjLzgcmH7QW0R42rJbsw1mslDr89EZKhoXweH5+XliTqfofgx15lAZZAg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.0",
-                "@aws-sdk/credential-provider-node": "^3.972.72",
+                "@aws-sdk/core": "^3.977.4",
+                "@aws-sdk/credential-provider-node": "^3.972.76",
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/core": "^3.29.8",
-                "@smithy/fetch-http-handler": "^5.6.10",
-                "@smithy/node-http-handler": "^4.9.10",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -265,15 +265,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.972.65",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.65.tgz",
-            "integrity": "sha512-udwNhRfDTfCB98mAHjjgsnKQlxygB4e0X+Obne/XjJpvVsF0YCQC8ZErd/8Z6IPoLQjtiKHzwqEDbZiLrJEnOg==",
+            "version": "3.972.70",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.70.tgz",
+            "integrity": "sha512-APdP0iODt39AkjCjzTFIoFrxDH/Cz3CpWRDKLcsJg7eOnfE1htkxL9BhDoe/xL7cXdoMwh2HBYv3DiT1uf64NQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.976.0",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+                "@aws-sdk/core": "^3.977.4",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.43",
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/core": "^3.29.4",
+                "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -2474,14 +2474,14 @@
         "raop-log-upload": {
             "version": "0.0.1",
             "dependencies": {
-                "@aws-sdk/client-s3": "^3.1092.0",
+                "@aws-sdk/client-s3": "^3.1099.0",
                 "@aws-sdk/s3-request-presigner": "^3.1099.0"
             }
         },
         "raop-support-payment": {
             "version": "0.0.1",
             "dependencies": {
-                "@aws-sdk/client-ses": "^3.1092.0",
+                "@aws-sdk/client-ses": "^3.1099.0",
                 "@aws-sdk/client-ssm": "^3.1099.0",
                 "stripe": "^22.4.0"
             }
@@ -2489,7 +2489,7 @@
         "raop-support-report": {
             "version": "0.0.1",
             "dependencies": {
-                "@aws-sdk/client-s3": "^3.1092.0",
+                "@aws-sdk/client-s3": "^3.1099.0",
                 "@aws-sdk/client-ssm": "^3.1099.0",
                 "@aws-sdk/s3-request-presigner": "^3.1099.0"
             }

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -12,7 +12,7 @@
         "typecheck": "npm run typecheck --workspaces"
     },
     "devDependencies": {
-        "@aws-sdk/client-s3": "^3.1092.0",
+        "@aws-sdk/client-s3": "^3.1099.0",
         "@aws-sdk/s3-request-presigner": "^3.1099.0",
         "@types/node": "^22.13.13",
         "archiver": "^7.0.1",

--- a/lambda/raop-log-upload/package.json
+++ b/lambda/raop-log-upload/package.json
@@ -5,7 +5,7 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-        "@aws-sdk/client-s3": "^3.1092.0",
+        "@aws-sdk/client-s3": "^3.1099.0",
         "@aws-sdk/s3-request-presigner": "^3.1099.0"
     }
 }

--- a/lambda/raop-support-payment/package.json
+++ b/lambda/raop-support-payment/package.json
@@ -5,7 +5,7 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-        "@aws-sdk/client-ses": "^3.1092.0",
+        "@aws-sdk/client-ses": "^3.1099.0",
         "@aws-sdk/client-ssm": "^3.1099.0",
         "stripe": "^22.4.0"
     }

--- a/lambda/raop-support-report/package.json
+++ b/lambda/raop-support-report/package.json
@@ -5,7 +5,7 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-        "@aws-sdk/client-s3": "^3.1092.0",
+        "@aws-sdk/client-s3": "^3.1099.0",
         "@aws-sdk/client-ssm": "^3.1099.0",
         "@aws-sdk/s3-request-presigner": "^3.1099.0"
     }


### PR DESCRIPTION
Combines #73 and #74 into a single grouped update, consistent with the new dependabot grouping config for `@aws-sdk/*`.