### PR TITLE
Fix ROCKNIX RK3326 SDL menu segfault by falling back to system SDL2

### DIFF
--- a/linux/rocknix/build_bundle.sh
+++ b/linux/rocknix/build_bundle.sh
@@ -58,6 +58,11 @@ cat > "${INSTALLER_PATH}" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Set to true to also install the SDL Doctor diagnostic as a second Tools
+# entry. Only needed when troubleshooting a menu that crashes on launch; it
+# writes a report to /storage/.config/raofflineproxy/sdl-doctor.log.
+INSTALL_SDL_DOCTOR="${INSTALL_SDL_DOCTOR:-false}"
+
 SCRIPT_PATH="$0"
 PAYLOAD_MARKER="__RAOFFLINEPROXY_PAYLOAD_BELOW__"
 SHARE_DIR="/storage/.local/share"
@@ -87,7 +92,7 @@ fi
 
 mv "${SHARE_DIR}/raofflineproxy-rocknix-bundle" "${TARGET_DIR}"
 cd "${TARGET_DIR}"
-./install.sh
+INSTALL_SDL_DOCTOR="${INSTALL_SDL_DOCTOR}" ./install.sh
 rm -f "${SCRIPT_PATH}"
 echo "RAOfflineProxy installed."
 exit 0

--- a/linux/rocknix/build_bundle.sh
+++ b/linux/rocknix/build_bundle.sh
@@ -48,6 +48,7 @@ chmod +x "${BUILD_DIR}/uninstall.sh"
 chmod +x "${BUILD_DIR}/scripts/launcher-raofflineproxy"
 chmod +x "${BUILD_DIR}/scripts/launcher-raofflineproxy-uninstall"
 chmod +x "${BUILD_DIR}/scripts/tool-launcher.sh"
+chmod +x "${BUILD_DIR}/scripts/sdl-doctor.sh"
 
 mkdir -p "${DIST_DIR}"
 rm -f "${TEMP_TARBALL}"

--- a/linux/rocknix/scripts/install.sh
+++ b/linux/rocknix/scripts/install.sh
@@ -9,6 +9,7 @@ LIB_DIR="${BASE_DIR}/lib"
 MODULES_DIR="/storage/.config/modules"
 TOOL_SOURCE="${BASE_DIR}/RAOfflineProxy.sh"
 TOOL_LAUNCHER="${MODULES_DIR}/RAOfflineProxy.sh"
+DOCTOR_LAUNCHER="${MODULES_DIR}/RAOfflineProxy-SDL-Doctor.sh"
 OLD_BIN="${BASE_DIR}/bin/raofflineproxy"
 UPDATE_STATUS_FILE="/storage/.config/raofflineproxy/update_status.json"
 WAS_RUNNING=0
@@ -38,12 +39,16 @@ cp "${SCRIPT_DIR}/scripts/launcher-raofflineproxy-uninstall" "${BIN_DIR}/raoffli
 cp "${SCRIPT_DIR}/scripts/tool-launcher.sh" "${TOOL_SOURCE}"
 cp "${SCRIPT_DIR}/scripts/tool-launcher.sh" "${TOOL_LAUNCHER}"
 
+cp "${SCRIPT_DIR}/scripts/sdl_probe.py" "${APP_DIR}/sdl_probe.py"
+cp "${SCRIPT_DIR}/scripts/sdl-doctor.sh" "${DOCTOR_LAUNCHER}"
+
 rm -f "${UPDATE_STATUS_FILE}"
 
 chmod +x "${BIN_DIR}/raofflineproxy"
 chmod +x "${BIN_DIR}/raofflineproxy-uninstall"
 chmod +x "${TOOL_SOURCE}"
 chmod +x "${TOOL_LAUNCHER}"
+chmod +x "${DOCTOR_LAUNCHER}"
 
 # Install the boot hook so the Tools entry is re-added on every reboot. The
 # proxy itself only autostarts when the user enables it (boot-reconcile gates

--- a/linux/rocknix/scripts/install.sh
+++ b/linux/rocknix/scripts/install.sh
@@ -12,6 +12,7 @@ TOOL_LAUNCHER="${MODULES_DIR}/RAOfflineProxy.sh"
 DOCTOR_LAUNCHER="${MODULES_DIR}/RAOfflineProxy-SDL-Doctor.sh"
 OLD_BIN="${BASE_DIR}/bin/raofflineproxy"
 UPDATE_STATUS_FILE="/storage/.config/raofflineproxy/update_status.json"
+INSTALL_SDL_DOCTOR="${INSTALL_SDL_DOCTOR:-false}"
 WAS_RUNNING=0
 RESTARTED=0
 
@@ -39,8 +40,13 @@ cp "${SCRIPT_DIR}/scripts/launcher-raofflineproxy-uninstall" "${BIN_DIR}/raoffli
 cp "${SCRIPT_DIR}/scripts/tool-launcher.sh" "${TOOL_SOURCE}"
 cp "${SCRIPT_DIR}/scripts/tool-launcher.sh" "${TOOL_LAUNCHER}"
 
-cp "${SCRIPT_DIR}/scripts/sdl_probe.py" "${APP_DIR}/sdl_probe.py"
-cp "${SCRIPT_DIR}/scripts/sdl-doctor.sh" "${DOCTOR_LAUNCHER}"
+if [ "${INSTALL_SDL_DOCTOR}" = "true" ]; then
+  cp "${SCRIPT_DIR}/scripts/sdl_probe.py" "${APP_DIR}/sdl_probe.py"
+  cp "${SCRIPT_DIR}/scripts/sdl-doctor.sh" "${DOCTOR_LAUNCHER}"
+  chmod +x "${DOCTOR_LAUNCHER}"
+else
+  rm -f "${DOCTOR_LAUNCHER}"
+fi
 
 rm -f "${UPDATE_STATUS_FILE}"
 
@@ -48,7 +54,6 @@ chmod +x "${BIN_DIR}/raofflineproxy"
 chmod +x "${BIN_DIR}/raofflineproxy-uninstall"
 chmod +x "${TOOL_SOURCE}"
 chmod +x "${TOOL_LAUNCHER}"
-chmod +x "${DOCTOR_LAUNCHER}"
 
 # Install the boot hook so the Tools entry is re-added on every reboot. The
 # proxy itself only autostarts when the user enables it (boot-reconcile gates

--- a/linux/rocknix/scripts/sdl-doctor.sh
+++ b/linux/rocknix/scripts/sdl-doctor.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# RAOfflineProxy SDL diagnostic for ROCKNIX.
+#
+# The menu segfaults inside pygame.display.set_mode() on some devices with no
+# Python traceback, and the launcher discards stdout/stderr, so the actual SDL
+# error and the kernel's segfault record were never captured. This runs the
+# window creation in isolation across a matrix of SDL configurations, keeping
+# stdout, stderr, exit signal and dmesg for each attempt in one report.
+
+source /etc/profile
+
+BASE_DIR="/storage/.local/share/raofflineproxy"
+REPORT="/storage/.config/raofflineproxy/sdl-doctor.log"
+
+export HOME="/storage"
+export XDG_CONFIG_HOME="/storage/.config"
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/var/run/0-runtime-dir}"
+export WAYLAND_DISPLAY="${WAYLAND_DISPLAY:-wayland-1}"
+export LD_LIBRARY_PATH="${BASE_DIR}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+export PYTHONPATH="${BASE_DIR}/app:${BASE_DIR}"
+
+PROBE="${BASE_DIR}/app/sdl_probe.py"
+BUNDLED_SDL="$(ls "${BASE_DIR}"/app/pygame_ce.libs/libSDL2-2-*.so.* 2>/dev/null | head -n1)"
+SYSTEM_SDL="$(ls /usr/lib/libSDL2-2.0.so.0* 2>/dev/null | head -n1)"
+
+mkdir -p "$(dirname "${REPORT}")"
+: > "${REPORT}"
+
+log() {
+  echo "$*" >> "${REPORT}"
+}
+
+log "=== RAOfflineProxy SDL doctor ==="
+log "date: $(date)"
+log "kernel: $(uname -a)"
+log "os: $(cat /etc/os-release 2>/dev/null | tr '\n' ' ')"
+log "python: $(/usr/bin/python3 -V 2>&1)"
+log ""
+
+log "=== environment ==="
+log "WAYLAND_DISPLAY=${WAYLAND_DISPLAY}"
+log "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}"
+log "wayland sockets: $(ls -1 "${XDG_RUNTIME_DIR}"/wayland-* 2>&1 | tr '\n' ' ')"
+log "bundled SDL: ${BUNDLED_SDL:-<none>}"
+log "system SDL:  ${SYSTEM_SDL:-<none>}"
+log ""
+
+log "=== system libraries SDL dlopens ==="
+for lib in libEGL.so.1 libGLESv2.so.2 libwayland-client.so.0 libwayland-egl.so.1 libdecor-0.so.0 libgbm.so.1 libdrm.so.2; do
+  found="$(ls /usr/lib/"${lib}"* 2>/dev/null | head -n1)"
+  log "${lib}: ${found:-MISSING}"
+done
+log ""
+
+log "=== GPU ==="
+log "drm cards: $(ls -1 /dev/dri 2>&1 | tr '\n' ' ')"
+log "mali module params: $(ls -1 /sys/module 2>/dev/null | grep -iE 'mali|bifrost|panfrost' | tr '\n' ' ')"
+log ""
+
+run_probe() {
+  local name="$1"
+  shift
+
+  log "--- probe: ${name} ---"
+  log "env: $*"
+
+  dmesg -c >/dev/null 2>&1
+
+  local out
+  out="$(env "$@" /usr/bin/python3 "${PROBE}" 2>&1)"
+  local code=$?
+
+  log "${out}"
+  log "exit_code=${code}"
+
+  if [ "${code}" -ge 128 ]; then
+    local signal=$((code - 128))
+    case "${signal}" in
+      11) log "died from SIGSEGV (segfault)" ;;
+      6)  log "died from SIGABRT" ;;
+      4)  log "died from SIGILL (illegal instruction)" ;;
+      7)  log "died from SIGBUS" ;;
+      *)  log "died from signal ${signal}" ;;
+    esac
+    log "dmesg:"
+    dmesg 2>/dev/null | grep -iE "segfault|trap|Code:|python3|mali" | tail -n 15 >> "${REPORT}"
+  fi
+
+  log ""
+}
+
+# Controls: do NOT touch the GPU or compositor. If these crash, the pygame
+# build itself is broken rather than the wayland/EGL path.
+run_probe "dummy driver (control)" SDL_VIDEODRIVER=dummy
+run_probe "offscreen driver (control)" SDL_VIDEODRIVER=offscreen
+
+# Baseline: what the menu actually does today.
+run_probe "wayland baseline" SDL_VIDEODRIVER=wayland SDL_LOGGING=video=verbose
+
+# libdecor is dlopened from the system and is a known crash source when the
+# wheel's SDL was built against a different version than the OS ships.
+run_probe "wayland, libdecor off" \
+  SDL_VIDEODRIVER=wayland SDL_VIDEO_WAYLAND_ALLOW_LIBDECOR=0 SDL_LOGGING=video=verbose
+
+run_probe "wayland, no framebuffer accel" \
+  SDL_VIDEODRIVER=wayland SDL_FRAMEBUFFER_ACCELERATION=0 SDL_LOGGING=video=verbose
+
+run_probe "wayland, libdecor off + no accel" \
+  SDL_VIDEODRIVER=wayland SDL_VIDEO_WAYLAND_ALLOW_LIBDECOR=0 \
+  SDL_FRAMEBUFFER_ACCELERATION=0 SDL_LOGGING=video=verbose
+
+run_probe "wayland, windowed" \
+  SDL_VIDEODRIVER=wayland PROBE_MODE=windowed SDL_LOGGING=video=verbose
+
+# The wheel bundles its own SDL 2.32.10 but borrows the system's wayland/EGL
+# stack. Every emulator on this device drives the same screen through the
+# system SDL, so try that combination instead.
+if [ -n "${SYSTEM_SDL}" ]; then
+  run_probe "wayland, system SDL2 preloaded" \
+    SDL_VIDEODRIVER=wayland LD_PRELOAD="${SYSTEM_SDL}" SDL_LOGGING=video=verbose
+else
+  log "--- probe: system SDL2 preloaded --- SKIPPED (no system SDL2 found)"
+  log ""
+fi
+
+run_probe "kmsdrm" SDL_VIDEODRIVER=kmsdrm SDL_LOGGING=video=verbose
+
+log "=== done ==="
+log "Report written to ${REPORT}"
+
+echo "SDL doctor finished."
+echo "Send this file to the developer:"
+echo "  ${REPORT}"
+echo ""
+echo "Press any key to close."
+read -r -n 1 -s

--- a/linux/rocknix/scripts/sdl_probe.py
+++ b/linux/rocknix/scripts/sdl_probe.py
@@ -1,0 +1,51 @@
+"""Minimal SDL display probe used by sdl-doctor.sh.
+
+Creates a window the same way the menu does and reports how far it got.
+Kept dependency-free so a crash here is unambiguously an SDL/driver crash.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    print(f"probe driver_env={os.environ.get('SDL_VIDEODRIVER', '<unset>')}", flush=True)
+
+    import pygame
+
+    print(f"probe pygame={pygame.version.ver} sdl={'.'.join(map(str, pygame.get_sdl_version()))}", flush=True)
+
+    pygame.init()
+    print("probe pygame.init ok", flush=True)
+
+    pygame.display.init()
+    print(f"probe display.init ok driver={pygame.display.get_driver()}", flush=True)
+    print(
+        f"probe num_displays={pygame.display.get_num_displays()} "
+        f"desktop_sizes={pygame.display.get_desktop_sizes()}",
+        flush=True,
+    )
+
+    mode = os.environ.get("PROBE_MODE", "fullscreen")
+    if mode == "windowed":
+        surface = pygame.display.set_mode((640, 480), 0)
+    elif mode == "explicit":
+        surface = pygame.display.set_mode((640, 480), pygame.FULLSCREEN)
+    else:
+        surface = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
+
+    print(f"probe set_mode ok size={surface.get_size()}", flush=True)
+
+    surface.fill((0, 128, 0))
+    pygame.display.flip()
+    print("probe flip ok", flush=True)
+
+    pygame.quit()
+    print("probe SUCCESS", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/linux/rocknix/scripts/sdl_probe.py
+++ b/linux/rocknix/scripts/sdl_probe.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
 
 def main() -> int:
@@ -39,6 +40,18 @@ def main() -> int:
     print(f"probe set_mode ok size={surface.get_size()}", flush=True)
 
     surface.fill((0, 128, 0))
+
+    # The menu draws through SDL_ttf and SDL_image, which are separate bundled
+    # libraries that also get interposed when the system SDL is preloaded.
+    font = pygame.font.Font(None, 24)
+    surface.blit(font.render("probe", True, (255, 255, 255)), (10, 10))
+    print("probe font ok", flush=True)
+
+    logo = Path(__file__).with_name("raofflineproxy") / "logo-320.png"
+    if logo.exists():
+        surface.blit(pygame.image.load(str(logo)), (10, 40))
+        print("probe image ok", flush=True)
+
     pygame.display.flip()
     print("probe flip ok", flush=True)
 

--- a/linux/rocknix/scripts/tool-launcher.sh
+++ b/linux/rocknix/scripts/tool-launcher.sh
@@ -23,6 +23,7 @@ export LD_LIBRARY_PATH="${BASE_DIR}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 export PYTHONPATH="${BASE_DIR}/app:${BASE_DIR}"
 
 DRIVER_CACHE_FILE="/storage/.config/raofflineproxy/rocknix_video_driver"
+STDOUT_LOG="/storage/.config/raofflineproxy/menu-stdout.log"
 DRIVER_CANDIDATES=(wayland kmsdrm x11)
 
 drivers_to_try=()
@@ -40,10 +41,18 @@ for d in "${DRIVER_CANDIDATES[@]}"; do
   [ "${already_queued}" -eq 0 ] && drivers_to_try+=("${d}")
 done
 
+mkdir -p "$(dirname "${STDOUT_LOG}")"
+
 exit_code=0
 for driver in "${drivers_to_try[@]}"; do
-  SDL_VIDEODRIVER="${driver}" /usr/bin/python3 -m raofflineproxy.main menu
-  exit_code=$?
+  echo "=== $(date) attempt driver=${driver} ===" >> "${STDOUT_LOG}"
+  # A native SDL crash never reaches Python, so the only record of it is what
+  # SDL and the loader wrote to stdout/stderr. Keep it instead of letting it
+  # vanish with the foot terminal.
+  SDL_VIDEODRIVER="${driver}" /usr/bin/python3 -m raofflineproxy.main menu \
+    2>&1 | tee -a "${STDOUT_LOG}"
+  exit_code="${PIPESTATUS[0]}"
+  echo "=== exit_code=${exit_code} ===" >> "${STDOUT_LOG}"
 
   if [ "${exit_code}" -lt 128 ]; then
     mkdir -p "$(dirname "${DRIVER_CACHE_FILE}")"

--- a/linux/rocknix/scripts/tool-launcher.sh
+++ b/linux/rocknix/scripts/tool-launcher.sh
@@ -4,10 +4,17 @@
 # Runs the controller-driven SDL menu fullscreen under the sway compositor.
 # The menu requests SDL fullscreen itself, so no sway_fullscreen call is needed.
 #
-# Some devices (e.g. RK3326 with the libmali blob) segfault inside SDL's
-# wayland/EGL init before the app's own pygame.error fallback can run, since a
-# native crash never reaches Python. Try candidate SDL video drivers in
-# separate attempts and remember whichever one first works.
+# Two device-specific failures are worked around here, both of which kill the
+# process natively inside SDL before any Python error handler can run:
+#
+#   1. The video driver may not be usable, so candidates are tried in separate
+#      attempts.
+#   2. On RK3326 with the libmali blob, the SDL 2.32.10 bundled inside the
+#      pygame-ce wheel segfaults creating a wayland window, while ROCKNIX's own
+#      libSDL2 (which every emulator on the device uses) works. Preloading the
+#      system library overrides the bundled one for that attempt.
+#
+# Whichever combination survives is cached and tried first next time.
 
 source /etc/profile
 
@@ -22,45 +29,56 @@ export WAYLAND_DISPLAY="${WAYLAND_DISPLAY:-wayland-1}"
 export LD_LIBRARY_PATH="${BASE_DIR}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 export PYTHONPATH="${BASE_DIR}/app:${BASE_DIR}"
 
-DRIVER_CACHE_FILE="/storage/.config/raofflineproxy/rocknix_video_driver"
-STDOUT_LOG="/storage/.config/raofflineproxy/menu-stdout.log"
+CONFIG_DIR="/storage/.config/raofflineproxy"
+ATTEMPT_CACHE_FILE="${CONFIG_DIR}/rocknix_sdl_attempt"
+STDOUT_LOG="${CONFIG_DIR}/menu-stdout.log"
 DRIVER_CANDIDATES=(wayland kmsdrm x11)
+SYSTEM_SDL="$(ls /usr/lib/libSDL2-2.0.so.0* 2>/dev/null | head -n1)"
 
-drivers_to_try=()
-if [ -r "${DRIVER_CACHE_FILE}" ]; then
-  cached_driver="$(cat "${DRIVER_CACHE_FILE}" 2>/dev/null)"
-  for d in "${DRIVER_CANDIDATES[@]}"; do
-    [ "${d}" = "${cached_driver}" ] && drivers_to_try+=("${d}")
-  done
-fi
+mkdir -p "${CONFIG_DIR}"
+
+# Attempts are "<driver>|<preload>", an empty preload meaning the wheel's own SDL.
+attempts=()
 for d in "${DRIVER_CANDIDATES[@]}"; do
-  already_queued=0
-  for q in "${drivers_to_try[@]}"; do
-    [ "${q}" = "${d}" ] && already_queued=1 && break
-  done
-  [ "${already_queued}" -eq 0 ] && drivers_to_try+=("${d}")
+  attempts+=("${d}|")
+  [ -n "${SYSTEM_SDL}" ] && attempts+=("${d}|${SYSTEM_SDL}")
 done
 
-mkdir -p "$(dirname "${STDOUT_LOG}")"
+ordered=()
+if [ -r "${ATTEMPT_CACHE_FILE}" ]; then
+  cached="$(cat "${ATTEMPT_CACHE_FILE}" 2>/dev/null)"
+  for a in "${attempts[@]}"; do
+    [ "${a}" = "${cached}" ] && ordered+=("${a}")
+  done
+fi
+for a in "${attempts[@]}"; do
+  already_queued=0
+  for q in "${ordered[@]}"; do
+    [ "${q}" = "${a}" ] && already_queued=1 && break
+  done
+  [ "${already_queued}" -eq 0 ] && ordered+=("${a}")
+done
 
 exit_code=0
-for driver in "${drivers_to_try[@]}"; do
-  echo "=== $(date) attempt driver=${driver} ===" >> "${STDOUT_LOG}"
+for attempt in "${ordered[@]}"; do
+  driver="${attempt%%|*}"
+  preload="${attempt#*|}"
+
+  echo "=== $(date) attempt driver=${driver} preload=${preload:-none} ===" >> "${STDOUT_LOG}"
   # A native SDL crash never reaches Python, so the only record of it is what
   # SDL and the loader wrote to stdout/stderr. Keep it instead of letting it
   # vanish with the foot terminal.
-  SDL_VIDEODRIVER="${driver}" /usr/bin/python3 -m raofflineproxy.main menu \
-    2>&1 | tee -a "${STDOUT_LOG}"
+  SDL_VIDEODRIVER="${driver}" LD_PRELOAD="${preload}" \
+    /usr/bin/python3 -m raofflineproxy.main menu 2>&1 | tee -a "${STDOUT_LOG}"
   exit_code="${PIPESTATUS[0]}"
   echo "=== exit_code=${exit_code} ===" >> "${STDOUT_LOG}"
 
   if [ "${exit_code}" -lt 128 ]; then
-    mkdir -p "$(dirname "${DRIVER_CACHE_FILE}")"
-    echo "${driver}" > "${DRIVER_CACHE_FILE}"
+    echo "${attempt}" > "${ATTEMPT_CACHE_FILE}"
     break
   fi
   # exit_code >= 128 means the process died from a signal (e.g. 139 = SIGSEGV);
-  # try the next driver instead of surfacing a crash for a fixable case.
+  # try the next combination instead of surfacing a crash for a fixable case.
 done
 
 exit "${exit_code}"

--- a/linux/rocknix/scripts/uninstall.sh
+++ b/linux/rocknix/scripts/uninstall.sh
@@ -5,6 +5,7 @@ BASE_DIR="/storage/.local/share/raofflineproxy"
 BUNDLE_DIR="/storage/.local/share/.raofflineproxy-rocknix-bundle"
 CONFIG_DIR="/storage/.config/raofflineproxy"
 TOOL_LAUNCHER="/storage/.config/modules/RAOfflineProxy.sh"
+DOCTOR_LAUNCHER="/storage/.config/modules/RAOfflineProxy-SDL-Doctor.sh"
 AUTOSTART_SCRIPT="/storage/.config/autostart/raofflineproxy.sh"
 
 if [ -x "${BASE_DIR}/bin/raofflineproxy" ]; then
@@ -17,6 +18,7 @@ if command -v pkill >/dev/null 2>&1; then
 fi
 
 rm -f "${TOOL_LAUNCHER}"
+rm -f "${DOCTOR_LAUNCHER}"
 rm -f "${AUTOSTART_SCRIPT}"
 
 # Remove app, config/cache, and this bundle synchronously. The uninstall is


### PR DESCRIPTION
Fixes the ROCKNIX RK3326 segfault where the SDL menu crashed back to EmulationStation on launch.

## Root cause

The pygame-ce wheel ships its own private `libSDL2-2-<hash>.0.so.0.3200.10`, but that SDL `dlopen`s the **system's** `libEGL.so.1`, `libwayland-client.so.0`, `libwayland-egl.so.1` and `libdecor-0.so.0`. That hybrid stack segfaults inside `pygame.display.set_mode()` on RK3326 with the libmali blob. ROCKNIX's own `/usr/lib/libSDL2-2.0.so.0`, which every emulator on the device already uses, works fine.

The crash is a native SIGSEGV, so no Python handler could ever catch it, and the driver-fallback loop couldn't help because driver choice was never the problem.

This also retires the earlier theory that the vendored pygame build had to be swapped. The pygame-ce swap did fix a different device (Anbernic RG DS, Mali-G52, #55) but never RK3326, because pygame was not the culprit.

## Changes

**`tool-launcher.sh`**
- Tries `<driver>|<preload>` combinations and caches the first survivor in `rocknix_sdl_attempt`. The bundled SDL is still attempted first, so devices where it already works are unaffected.
- Tees stdout/stderr to `menu-stdout.log`. Previously these were discarded entirely, which is why months of logs never showed the cause — a native SDL crash leaves no Python traceback, so that output was the only record.

**`sdl-doctor.sh` + `sdl_probe.py` (new)**

A diagnostic installed as a second Tools entry. Runs window creation across a matrix of SDL configurations, capturing stdout, stderr, decoded exit signal and filtered `dmesg` per attempt, plus an environment survey. The `SDL_VIDEODRIVER=dummy` control probe is what identified the fault as the GPU/wayland path rather than pygame itself.

## Verification

Diagnostic output from an affected device (GKD Pixel 2, `HW_DEVICE="RK3326"`):

| Probe | Result |
| --- | --- |
| dummy / offscreen (control) | SUCCESS — pygame build is fine |
| wayland baseline | SIGSEGV |
| wayland, libdecor off | SIGSEGV |
| wayland, windowed | SIGSEGV |
| **wayland, system SDL2 preloaded** | **SUCCESS** |
| kmsdrm | not available (sway holds DRM master) |

Attempt ordering verified across all three cache states: fresh affected device recovers after one crash and caches; returning device goes straight to the working combination; devices where the bundled SDL works keep their current behavior.

Confirmed working end-to-end on-device by the reporter, so SDL_ttf and SDL_image are fine under the preload, not just base SDL.

Does not address the separate RG DS dual-screen rendering issue in #55, which remains open.

## SDL Doctor is opt-in

The diagnostic scripts always ship in the bundle, but the Tools entry is only created when the toggle at the top of the generated installer is flipped:

```bash
INSTALL_SDL_DOCTOR="${INSTALL_SDL_DOCTOR:-false}"
```

So a normal install is unchanged and no extra Tools entry appears. For a support case, the reporter edits that one line to `true` (or runs `INSTALL_SDL_DOCTOR=true ./RAOfflineProxy-...-Install.sh`) — no rebuild needed. Switching it back off removes the entry again rather than leaving a stale one behind.
