### PR TITLE
Show whether cached achievements were unlocked offline or online

### DIFF
--- a/app/src/main/java/com/raofflineproxy/ui/CachedGamesAdapter.kt
+++ b/app/src/main/java/com/raofflineproxy/ui/CachedGamesAdapter.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
-import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -53,14 +52,12 @@ class CachedGamesAdapter(
             notifyDataSetChanged()
         }
 
-    private var pendingAchievementIds: Set<Int> = emptySet()
     private var offlineEarnedAchievementIds: Set<Int> = emptySet()
 
     @SuppressLint("NotifyDataSetChanged")
-    fun setAwardOrigins(pendingIds: Set<Int>, offlineEarnedIds: Set<Int>) {
-        if (pendingIds == pendingAchievementIds && offlineEarnedIds == offlineEarnedAchievementIds) return
-        pendingAchievementIds = pendingIds
-        offlineEarnedAchievementIds = offlineEarnedIds
+    fun setOfflineEarnedAchievements(ids: Set<Int>) {
+        if (ids == offlineEarnedAchievementIds) return
+        offlineEarnedAchievementIds = ids
         notifyDataSetChanged()
     }
 
@@ -141,23 +138,8 @@ class CachedGamesAdapter(
                 achievement.points
             )
 
-            val originView = view.findViewById<TextView>(R.id.tv_achievement_origin)
-            val origin = when {
-                !achievement.unlocked -> null
-                pendingAchievementIds.contains(achievement.id) ->
-                    R.string.cached_game_origin_syncing to R.color.warning_text
-                offlineEarnedAchievementIds.contains(achievement.id) ->
-                    R.string.cached_game_origin_offline to R.color.primary
-                else -> R.string.cached_game_origin_online to R.color.info_text
-            }
-            if (origin == null) {
-                originView.visibility = View.GONE
-            } else {
-                originView.visibility = View.VISIBLE
-                originView.setText(origin.first)
-                originView.setTextColor(ContextCompat.getColor(view.context, origin.second))
-                originView.alpha = if (origin.first == R.string.cached_game_origin_online) 0.6f else 1f
-            }
+            view.findViewById<TextView>(R.id.tv_achievement_origin).visibility =
+                if (offlineEarnedAchievementIds.contains(achievement.id)) View.VISIBLE else View.GONE
             return view
         }
 

--- a/app/src/main/java/com/raofflineproxy/ui/CachedGamesAdapter.kt
+++ b/app/src/main/java/com/raofflineproxy/ui/CachedGamesAdapter.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -51,6 +52,17 @@ class CachedGamesAdapter(
             field = value
             notifyDataSetChanged()
         }
+
+    private var pendingAchievementIds: Set<Int> = emptySet()
+    private var offlineEarnedAchievementIds: Set<Int> = emptySet()
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun setAwardOrigins(pendingIds: Set<Int>, offlineEarnedIds: Set<Int>) {
+        if (pendingIds == pendingAchievementIds && offlineEarnedIds == offlineEarnedAchievementIds) return
+        pendingAchievementIds = pendingIds
+        offlineEarnedAchievementIds = offlineEarnedIds
+        notifyDataSetChanged()
+    }
 
     private fun visibleAchievements(game: CachedGame): List<CachedAchievement> =
         if (showLocked) game.achievements else game.achievements.filter { it.unlocked }
@@ -128,6 +140,24 @@ class CachedGamesAdapter(
                 R.string.points_format,
                 achievement.points
             )
+
+            val originView = view.findViewById<TextView>(R.id.tv_achievement_origin)
+            val origin = when {
+                !achievement.unlocked -> null
+                pendingAchievementIds.contains(achievement.id) ->
+                    R.string.cached_game_origin_syncing to R.color.warning_text
+                offlineEarnedAchievementIds.contains(achievement.id) ->
+                    R.string.cached_game_origin_offline to R.color.primary
+                else -> R.string.cached_game_origin_online to R.color.info_text
+            }
+            if (origin == null) {
+                originView.visibility = View.GONE
+            } else {
+                originView.visibility = View.VISIBLE
+                originView.setText(origin.first)
+                originView.setTextColor(ContextCompat.getColor(view.context, origin.second))
+                originView.alpha = if (origin.first == R.string.cached_game_origin_online) 0.6f else 1f
+            }
             return view
         }
 

--- a/app/src/main/java/com/raofflineproxy/ui/CachedGamesFragment.kt
+++ b/app/src/main/java/com/raofflineproxy/ui/CachedGamesFragment.kt
@@ -149,6 +149,10 @@ class CachedGamesFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.state.collect { state ->
                 gamesAdapter?.showLocked = state.showLockedAchievements
+                gamesAdapter?.setAwardOrigins(
+                    state.pendingAwards.mapTo(HashSet()) { it.achievementId },
+                    state.awardHistory.mapTo(HashSet()) { it.achievementId }
+                )
                 val actionsEnabled = state.isOnline
                     && !state.scanInProgress
                 val showSmartCache = !viewModel.isSmartCacheDisabledForShizuku(state)

--- a/app/src/main/java/com/raofflineproxy/ui/CachedGamesFragment.kt
+++ b/app/src/main/java/com/raofflineproxy/ui/CachedGamesFragment.kt
@@ -149,8 +149,7 @@ class CachedGamesFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.state.collect { state ->
                 gamesAdapter?.showLocked = state.showLockedAchievements
-                gamesAdapter?.setAwardOrigins(
-                    state.pendingAwards.mapTo(HashSet()) { it.achievementId },
+                gamesAdapter?.setOfflineEarnedAchievements(
                     state.awardHistory.mapTo(HashSet()) { it.achievementId }
                 )
                 val actionsEnabled = state.isOnline

--- a/app/src/main/res/layout/item_unlocked_achievement.xml
+++ b/app/src/main/res/layout/item_unlocked_achievement.xml
@@ -60,6 +60,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="1dp"
+            android:text="@string/cached_game_origin_offline"
+            android:textColor="@color/primary"
             android:textSize="11sp"
             android:textStyle="bold"
             android:visibility="gone" />

--- a/app/src/main/res/layout/item_unlocked_achievement.xml
+++ b/app/src/main/res/layout/item_unlocked_achievement.xml
@@ -61,7 +61,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="1dp"
             android:text="@string/cached_game_origin_offline"
-            android:textColor="@color/primary"
+            android:textColor="@color/achievement_offline_tag"
             android:textSize="11sp"
             android:textStyle="bold"
             android:visibility="gone" />

--- a/app/src/main/res/layout/item_unlocked_achievement.xml
+++ b/app/src/main/res/layout/item_unlocked_achievement.xml
@@ -41,12 +41,29 @@
 
     </LinearLayout>
 
-    <TextView
-        android:id="@+id/tv_points"
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
-        android:alpha="0.6"
-        android:textSize="12sp" />
+        android:gravity="end"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/tv_points"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:alpha="0.6"
+            android:textSize="12sp" />
+
+        <TextView
+            android:id="@+id/tv_achievement_origin"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="1dp"
+            android:textSize="11sp"
+            android:textStyle="bold"
+            android:visibility="gone" />
+
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="console_header_background">#FF111111</color>
+    <color name="achievement_offline_tag">#FF8AB4E8</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -21,4 +21,5 @@
     <color name="emulator_toggle_text_active">#FF1A1400</color>
     <color name="console_header_background">#FFFFFFFF</color>
     <color name="toggle_button_background_inactive">#FF4A4A4A</color>
+    <color name="achievement_offline_tag">#FF1C5182</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -267,8 +267,6 @@
     <string name="cached_game_collapse">Hide achievements</string>
     <string name="cached_game_no_description">No description.</string>
     <string name="cached_game_origin_offline">Offline</string>
-    <string name="cached_game_origin_online">Online</string>
-    <string name="cached_game_origin_syncing">Syncing</string>
 
     <!-- Pending awards adapter -->
     <string name="achievement_title_hardcore">%s (Hardcore)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -266,6 +266,9 @@
     <string name="cached_game_expand">Show achievements</string>
     <string name="cached_game_collapse">Hide achievements</string>
     <string name="cached_game_no_description">No description.</string>
+    <string name="cached_game_origin_offline">Offline</string>
+    <string name="cached_game_origin_online">Online</string>
+    <string name="cached_game_origin_syncing">Syncing</string>
 
     <!-- Pending awards adapter -->
     <string name="achievement_title_hardcore">%s (Hardcore)</string>


### PR DESCRIPTION
In the Cached Games achievement dropdown, each unlocked achievement now shows a small tag for how it was earned:

- **Offline** — unlocked through this proxy (it's in Awards History)
- **Syncing** — earned offline, still queued to sync
- **Online** — unlocked, but not through this app (already on the account when the game was cached)

The origin is derived from the award queue (pending + flushed history), so it stays fully offline and adds no network calls. Locked achievements are unaffected.

Note: the Offline tag comes from Awards History, so clearing award history will make those achievements show as Online, and it only reflects unlocks earned through this app.