### PR TITLE
Fix 403 game lookups by not reusing cached client User-Agent (#89)

### DIFF
--- a/linux/raofflineproxy/config.py
+++ b/linux/raofflineproxy/config.py
@@ -60,9 +60,9 @@ def resolve_config_dir() -> Path:
 
 RA_HOST = "https://retroachievements.org"
 RA_MEDIA_HOST = "https://media.retroachievements.org"
-PROXY_UA_TAG = "RAOfflineProxy/Linux/1.10.0-alpha2"
+APP_VERSION = os.environ.get("RAOFFLINEPROXY_APP_VERSION") or "1.10.0-alpha7"
+PROXY_UA_TAG = f"RAOfflineProxy/Linux/{APP_VERSION}"
 FALLBACK_USER_AGENT = "RetroArch/1.21.0 (Linux)"
-APP_VERSION = os.environ.get("RAOFFLINEPROXY_APP_VERSION") or "1.10.0-alpha2"
 
 DEFAULT_PROXY_PORT = 8080
 MIN_PROXY_PORT = 1024

--- a/linux/raofflineproxy/flusher.py
+++ b/linux/raofflineproxy/flusher.py
@@ -32,6 +32,7 @@ from .utils import (
     proxy_user_agent,
     redact_query_tokens,
     replace_or_append_form_param,
+    self_user_agent,
     sha256_hex,
 )
 
@@ -342,7 +343,7 @@ def flush_pending_awards(storage: Storage, config_data: dict) -> FlushOutcome:
             pending_remaining=0,
         )
 
-    user_agent = storage.load_user_agent(FALLBACK_USER_AGENT)
+    user_agent = self_user_agent()
     credentials = resolve_credentials(storage, config_data, user_agent)
     if credentials is None:
         LOGGER.warning("Flush aborted: no RetroAchievements credentials")

--- a/linux/raofflineproxy/network.py
+++ b/linux/raofflineproxy/network.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 import ssl
@@ -282,10 +283,17 @@ def http_get(url: str, user_agent: str) -> str:
                 time.sleep(retry_after)
                 continue
 
+            api_error = describe_api_error(error)
+            if api_error:
+                # HTTPError.reason is a read-only view of .msg, and .msg is what
+                # str(error) renders, so this is the only way to make the
+                # message callers surface carry RA's actual reason.
+                error.msg = api_error
             LOGGER.warning(
-                "GET failed status=%s reason=%s url=%s",
+                "GET failed status=%s reason=%s ua=%s url=%s",
                 error.code,
                 error.reason,
+                user_agent,
                 redacted_url(url),
             )
             raise
@@ -317,6 +325,28 @@ def http_get_bytes(url: str, user_agent: str) -> tuple[bytes, str] | None:
             return response.read(), response_content_type(response) or "application/octet-stream"
     except Exception:
         return None
+
+
+def describe_api_error(error: urllib.error.HTTPError) -> str | None:
+    """Extracts RetroAchievements' own error text from a failed response.
+
+    RA answers dorequest.php failures with a JSON body carrying a machine
+    readable Code and a human readable Error. Without this the caller only ever
+    sees "HTTP Error 403: Forbidden", which hides the actual cause.
+    """
+    try:
+        payload = json.loads(error.read().decode("utf-8", errors="replace"))
+    except Exception:
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    code = payload.get("Code")
+    message = payload.get("Error")
+    if code and message:
+        return f"{code}: {message}"
+    return code or message or None
 
 
 def api_action_from_url(url: str) -> str | None:

--- a/linux/raofflineproxy/proxy_service.py
+++ b/linux/raofflineproxy/proxy_service.py
@@ -65,6 +65,7 @@ from .utils import (
     proxy_user_agent,
     redact_form_tokens,
     redact_query_tokens,
+    self_user_agent,
     sha256_hex,
 )
 
@@ -283,7 +284,7 @@ class ProxyRuntimeServer(ThreadingTCPServer):
     def refresh_reachability(self, force_probe: bool) -> bool:
         self.has_internet = probe_retroachievements(
             self.config_data,
-            user_agent=self.storage.load_user_agent(FALLBACK_USER_AGENT),
+            user_agent=self_user_agent(),
             force=force_probe,
         )
         if not self.has_internet:
@@ -991,7 +992,7 @@ class PeriodicRefresh(threading.Thread):
         while not self.stop_event.wait(self.interval_seconds):
             if not self.server.is_online():
                 continue
-            user_agent = self.server.storage.load_user_agent(FALLBACK_USER_AGENT)
+            user_agent = self_user_agent()
             credentials = resolve_credentials(
                 self.server.storage,
                 self.server.config_data,

--- a/linux/raofflineproxy/rom_browser.py
+++ b/linux/raofflineproxy/rom_browser.py
@@ -35,7 +35,7 @@ from .rom_hashing import (
     supported_rom_extensions,
 )
 from .storage import Storage
-from .utils import proxy_user_agent
+from .utils import proxy_user_agent, self_user_agent
 
 LOGGER = logging.getLogger("raofflineproxy")
 SUPPORTED_ROM_EXTENSIONS = supported_rom_extensions()
@@ -398,7 +398,7 @@ def fetch_game_id(
 
 
 def add_rom_to_cache(path: Path, storage: Storage, config_data: dict) -> AddRomResult:
-    user_agent = storage.load_user_agent(FALLBACK_USER_AGENT)
+    user_agent = self_user_agent()
     credentials = resolve_credentials(storage, config_data, user_agent)
     if credentials is None:
         return AddRomResult(False, "RetroAchievements login required")
@@ -832,7 +832,7 @@ def ensure_game_preview(
         if cached is not None:
             return cached
 
-    user_agent = proxy_user_agent(storage.load_user_agent(FALLBACK_USER_AGENT))
+    user_agent = self_user_agent()
 
     if image_path:
         media_url = f"{RA_MEDIA_HOST}{image_path}"

--- a/linux/raofflineproxy/storage.py
+++ b/linux/raofflineproxy/storage.py
@@ -733,13 +733,6 @@ class Storage:
     def clear_invalid_token(self) -> None:
         self.delete_cache(cache_keys.AUTH_INVALID_TOKEN)
 
-    def load_user_agent(self, fallback: str) -> str:
-        entry = self.get_cache(cache_keys.USER_AGENT)
-        if entry is None:
-            return fallback
-        user_agent = entry.get("responseBody", "")
-        return user_agent if user_agent else fallback
-
 
 def _salvage_pending_award_count(quarantined_path: Path) -> int | None:
     # "Extra data" corruption (a valid document with garbage appended after it,

--- a/linux/raofflineproxy/utils.py
+++ b/linux/raofflineproxy/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 from urllib.parse import parse_qsl, quote_plus, unquote_plus, urlencode, urlsplit
 
-from .config import PROXY_UA_TAG
+from .config import FALLBACK_USER_AGENT, PROXY_UA_TAG
 
 
 def sha256_hex(value: str) -> str:
@@ -68,6 +68,18 @@ def proxy_user_agent(original: str) -> str:
     if PROXY_UA_TAG in original:
         return original
     return f"{original} {PROXY_UA_TAG}"
+
+
+def self_user_agent() -> str:
+    """User-Agent for requests the proxy makes on its own behalf.
+
+    Never reuse a cached client User-Agent here. RetroAchievements reads the
+    first token as the client identity and rejects blocked clients with 403 on
+    every endpoint, so borrowing an emulator's identity makes our own lookups
+    fail whenever that emulator is blocked. Only forwarded requests should
+    carry a client's User-Agent.
+    """
+    return proxy_user_agent(FALLBACK_USER_AGENT)
 
 
 def canonical_reason_phrase(code: int) -> str:

--- a/linux/rocknix/build_bundle.sh
+++ b/linux/rocknix/build_bundle.sh
@@ -7,7 +7,7 @@ DIST_DIR="${SCRIPT_DIR}/dist"
 BUILD_DIR="${DIST_DIR}/raofflineproxy-rocknix-bundle"
 APP_DIR="${BUILD_DIR}/app"
 LIB_DIR="${BUILD_DIR}/lib"
-VERSION="${RAOFFLINEPROXY_APP_VERSION:-1.10.0-alpha2}"
+VERSION="${RAOFFLINEPROXY_APP_VERSION:-1.10.0-alpha7-uafix}"
 INSTALLER_PATH="${DIST_DIR}/RAOfflineProxy-Rocknix-v${VERSION}-Install.sh"
 TEMP_TARBALL="${DIST_DIR}/.raofflineproxy-rocknix-bundle.tar.gz"
 

--- a/linux/tests/test_linux_award_parity.py
+++ b/linux/tests/test_linux_award_parity.py
@@ -340,7 +340,7 @@ class LinuxAwardParityTests(unittest.TestCase):
             finally:
                 store.close()
 
-    def test_flush_pending_awards_loads_user_agent_before_resolving_credentials(
+    def test_flush_pending_awards_resolves_credentials_with_our_own_user_agent(
         self,
     ) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -369,7 +369,7 @@ class LinuxAwardParityTests(unittest.TestCase):
 
                 outcome = flusher.flush_pending_awards(store, {})
 
-                self.assertEqual(observed["user_agent"], config.FALLBACK_USER_AGENT)
+                self.assertEqual(observed["user_agent"], utils.self_user_agent())
                 self.assertEqual(
                     outcome.last_error,
                     "No RetroAchievements credentials available",

--- a/linux/tests/test_linux_network.py
+++ b/linux/tests/test_linux_network.py
@@ -1,3 +1,4 @@
+import io
 import unittest
 import urllib.error
 import logging
@@ -41,6 +42,41 @@ class LinuxNetworkTests(unittest.TestCase):
             self.assertIn("GET connection failed", output)
             self.assertIn("t=%3Credacted%3E", output)
             self.assertNotIn("secret", output)
+        finally:
+            network.urllib.request.urlopen = original_urlopen
+
+    def test_http_get_surfaces_retroachievements_error_code(self) -> None:
+        headers = Message()
+        headers["Content-Type"] = "application/json"
+        body = io.BytesIO(
+            b'{"Success":false,"Status":403,"Code":"unsupported_client",'
+            b'"Error":"This client is not supported.","GameID":0}'
+        )
+        original_urlopen = network.urllib.request.urlopen
+        try:
+            network.urllib.request.urlopen = lambda _request, timeout=0, context=None: (
+                _ for _ in ()
+            ).throw(
+                urllib.error.HTTPError(
+                    "https://retroachievements.org/dorequest.php",
+                    403,
+                    "Forbidden",
+                    headers,
+                    body,
+                )
+            )
+
+            with self.assertLogs("raofflineproxy", level="WARNING") as logs:
+                with self.assertRaises(urllib.error.HTTPError) as caught:
+                    network.http_get(
+                        "https://retroachievements.org/dorequest.php?r=gameid&m=abc",
+                        "Dolphin/2407 RAOfflineProxy/Linux/1.10.0-alpha2",
+                    )
+
+            self.assertIn("unsupported_client", str(caught.exception))
+            output = "\n".join(logs.output)
+            self.assertIn("unsupported_client", output)
+            self.assertIn("Dolphin/2407", output)
         finally:
             network.urllib.request.urlopen = original_urlopen
 

--- a/linux/tests/test_linux_rom_browser.py
+++ b/linux/tests/test_linux_rom_browser.py
@@ -16,6 +16,7 @@ from linux.raofflineproxy import rom_hashing
 from linux.raofflineproxy import storage
 from linux.raofflineproxy import smart_cache
 from linux.raofflineproxy import cache_keys
+from linux.raofflineproxy import utils
 
 # The real ROM hasher goes through the native libraproxy_rchash.so, which is
 # only built for the Linux device targets. On other hosts (e.g. a macOS dev
@@ -349,6 +350,68 @@ class LinuxRomBrowserTests(unittest.TestCase):
                     cached_patch["sourceRomPath"],
                     f"/{root.name}/tetris.gb",
                 )
+            finally:
+                rom_browser.hash_rom_candidates = original_hash_rom_candidates
+                rom_browser.resolve_credentials = original_resolve_credentials
+                rom_browser.fetch_game_id = original_fetch_game_id
+                rom_browser.cache_game = original_cache_game
+                store.close()
+
+    def test_add_rom_to_cache_ignores_cached_client_user_agent(self) -> None:
+        """A blocked emulator must not lend its identity to our own lookups.
+
+        RetroAchievements rejects blocked clients with 403 on every endpoint, so
+        reusing a cached client User-Agent broke caching for unrelated consoles.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            db_path = root / "test.sqlite3"
+            rom_path = root / "tetris.gb"
+            rom_path.write_bytes(b"rom")
+            store = storage.Storage(database_path=db_path)
+            store.upsert_cache("ua::last", "Dolphin/2407")
+            observed: dict[str, str] = {}
+            original_hash_rom_candidates = rom_browser.hash_rom_candidates
+            original_resolve_credentials = rom_browser.resolve_credentials
+            original_fetch_game_id = rom_browser.fetch_game_id
+            original_cache_game = rom_browser.cache_game
+            try:
+                rom_browser.hash_rom_candidates = lambda _path: ["abcd"]
+                rom_browser.resolve_credentials = lambda _store, _config, _ua: {
+                    "user": "misantronic",
+                    "token": "token",
+                }
+
+                def fake_fetch_game_id(
+                    _hash, _credentials, user_agent, _config_data, cache_store
+                ):
+                    observed["user_agent"] = user_agent
+                    cache_store.upsert_cache(
+                        cache_keys.game_id("abcd"), '{"GameID":10701}'
+                    )
+                    return 10701
+
+                def fake_cache_game(
+                    game_id,
+                    _hash_value,
+                    credentials,
+                    _user_agent,
+                    cache_store,
+                    _config_data,
+                    cache_images=True,
+                ):
+                    cache_store.upsert_cache(
+                        cache_keys.patch(game_id, credentials["user"]),
+                        '{"Success":true,"PatchData":{"Title":"Tetris"}}',
+                    )
+
+                rom_browser.fetch_game_id = fake_fetch_game_id
+                rom_browser.cache_game = fake_cache_game
+
+                rom_browser.add_rom_to_cache(rom_path, store, {})
+
+                self.assertNotIn("Dolphin", observed["user_agent"])
+                self.assertEqual(observed["user_agent"], utils.self_user_agent())
             finally:
                 rom_browser.hash_rom_candidates = original_hash_rom_candidates
                 rom_browser.resolve_credentials = original_resolve_credentials

--- a/linux/tests/test_linux_utils.py
+++ b/linux/tests/test_linux_utils.py
@@ -1,6 +1,6 @@
 import unittest
 
-from linux.raofflineproxy import utils
+from linux.raofflineproxy import config, utils
 
 
 class LinuxUtilsRedactTests(unittest.TestCase):
@@ -43,6 +43,14 @@ class LinuxUtilsRedactTests(unittest.TestCase):
             utils.redact_form_tokens("r=login2&u=user&p=hunter2&t=secret"),
             "r=login2&u=user&p=%3Ctoken%3E&t=%3Ctoken%3E",
         )
+
+
+class LinuxSelfUserAgentTests(unittest.TestCase):
+    def test_self_user_agent_leads_with_an_accepted_client(self) -> None:
+        self.assertTrue(utils.self_user_agent().startswith(config.FALLBACK_USER_AGENT))
+
+    def test_self_user_agent_carries_the_proxy_tag(self) -> None:
+        self.assertIn(config.PROXY_UA_TAG, utils.self_user_agent())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #89.

## Problem

The proxy identified itself to RetroAchievements with `ua::last` — the User-Agent of whichever emulator most recently passed through it. RA reads the first token of the User-Agent as the client identity and answers blocked clients with `403 unsupported_client` on every endpoint, including `r=gameid`.

So one emulator RA rejects poisoned every request the proxy made on its own behalf, for every console. The reporter's Game Boy folder scan failed because a GameCube emulator's identity was cached. `ua::last` is exempt from cache eviction, so it never expired.

Worth noting: RA sets `clientVersion = 'Unknown'` when it can't parse a version out of the User-Agent, and that sorts below every minimum, so a current build with a versionless UA is rejected exactly like an ancient one.

## Fix

New `self_user_agent()` used for every request the proxy originates — manual ROM caching, preview images, the reachability probe, and the background refresher. Genuinely forwarded emulator requests still carry the client's real User-Agent via `build_forward_headers`, and pending awards still replay under the User-Agent that earned them.

`Storage.load_user_agent` is removed; it existed only to feed this bug.

## Diagnostics

`http_get` was discarding RA's response body, so the only thing that ever surfaced was `HTTP Error 403: Forbidden`. It now extracts RA's own `Code`/`Error` and logs the outgoing User-Agent:

    before: GET failed status=403 reason=Forbidden url=...
    after:  GET failed status=403 reason=unsupported_client: This client is not supported. ua=... url=...

## Verification

Confirmed against the live RA API using the exact hash from the report:

    RetroArch/1.21.0 (Linux) RAOfflineProxy/Linux/...  ->  {"Success":true,"GameID":504}
    Dolphin/2407 RAOfflineProxy/Linux/...              ->  403 unsupported_client

Reporter confirmed the test build resolves the issue on ROCKNIX.

Existing installs self-heal on upgrade — the poisoned row is simply no longer read.

## Notes

- `PROXY_UA_TAG` now derives from `APP_VERSION` instead of being a second hardcoded copy that had drifted.
- `APP_VERSION` is bumped to `1.10.0-alpha7`. It is shared by the muOS, Knulli and Onion bundles, whose own build scripts still default to `alpha2` filenames.
- Android has the same defect (`RomScanner.kt`, `MainViewModel.kt`, `AwardFlusher.kt`, `ProxyService.kt`) and is not addressed here.