### PR TITLE
Fix ROCKNIX credentials and offline caching on dual-screen devices (#92, #95)

### DIFF
--- a/linux/raofflineproxy/auth.py
+++ b/linux/raofflineproxy/auth.py
@@ -4,7 +4,12 @@ import json
 import logging
 
 from . import cache_keys
-from .config import FALLBACK_USER_AGENT, detect_retroarch_cfg, upstream_host
+from .config import (
+    FALLBACK_USER_AGENT,
+    detect_retroarch_cfg,
+    detect_rocknix_append_cfg,
+    upstream_host,
+)
 from .network import build_api_url, http_get
 from .retroarch_cfg import (
     cheevos_append_cfg_path,
@@ -26,10 +31,15 @@ def resolve_credentials(
     cfg_path = str(config_data.get("retroarch_cfg") or detect_retroarch_cfg())
     # Also check the cheevos appendconfig — muOS stores credentials there
     cheevos_cfg = str(cheevos_append_cfg_path(cfg_path)) if cfg_path else None
+    # ROCKNIX goes further: setsettings.sh deletes cheevos_username/cheevos_password
+    # from retroarch.cfg on every game launch and writes them only into its own
+    # --appendconfig file, so that file is the sole source of credentials there.
+    rocknix_cfg = detect_rocknix_append_cfg(config_data)
 
     token_credentials = (
         load_retroarch_token_credentials(cfg_path)
         or load_retroarch_token_credentials(cheevos_cfg)
+        or load_retroarch_token_credentials(rocknix_cfg, last_wins=True)
     )
     if token_credentials is not None:
         return cache_token_credentials(storage, token_credentials)
@@ -41,6 +51,7 @@ def resolve_credentials(
     password_credentials = (
         load_retroarch_password_credentials(cfg_path)
         or load_retroarch_password_credentials(cheevos_cfg)
+        or load_retroarch_password_credentials(rocknix_cfg, last_wins=True)
     )
     if password_credentials is not None:
         refreshed = login_and_cache_token(

--- a/linux/raofflineproxy/config.py
+++ b/linux/raofflineproxy/config.py
@@ -19,6 +19,10 @@ DEFAULT_ROCKNIX_RETROARCH_CFG = Path("/storage/.config/retroarch/retroarch.cfg")
 DEFAULT_ROCKNIX_CONFIG_DIR = Path("/storage/.config/raofflineproxy")
 DEFAULT_ROCKNIX_PPSSPP_INI = Path("/storage/.config/ppsspp/PSP/SYSTEM/ppsspp.ini")
 DEFAULT_ROCKNIX_DOLPHIN_CONFIG_DIR = Path("/storage/.config/dolphin-emu")
+# ROCKNIX launches RetroArch with --appendconfig pointing here, and its setsettings.sh
+# strips cheevos_username/cheevos_password out of retroarch.cfg on every launch, writing
+# the live values into this file instead. It is the only place those credentials exist.
+DEFAULT_ROCKNIX_APPEND_CFG = Path("/tmp/.retroarch.cfg")
 OS_RELEASE_PATH = Path("/etc/os-release")
 
 
@@ -60,7 +64,7 @@ def resolve_config_dir() -> Path:
 
 RA_HOST = "https://retroachievements.org"
 RA_MEDIA_HOST = "https://media.retroachievements.org"
-APP_VERSION = os.environ.get("RAOFFLINEPROXY_APP_VERSION") or "1.10.0-alpha7"
+APP_VERSION = os.environ.get("RAOFFLINEPROXY_APP_VERSION") or "1.10.0-alpha8"
 PROXY_UA_TAG = f"RAOfflineProxy/Linux/{APP_VERSION}"
 FALLBACK_USER_AGENT = "RetroArch/1.21.0 (Linux)"
 
@@ -211,6 +215,21 @@ def detect_retroarch_cfg() -> str:
         return str(Path("/mnt/SDCARD/RetroArch/.retroarch/retroarch.cfg"))
 
     return str(Path.home() / ".config" / "retroarch" / "retroarch.cfg")
+
+
+def detect_rocknix_append_cfg(config_data: dict | None = None) -> str | None:
+    configured = (config_data or {}).get("rocknix_append_cfg")
+    if configured:
+        return str(configured)
+
+    env_override = os.environ.get("RAOFFLINEPROXY_ROCKNIX_APPEND_CFG")
+    if env_override:
+        return env_override
+
+    if running_on_rocknix() and DEFAULT_ROCKNIX_APPEND_CFG.exists():
+        return str(DEFAULT_ROCKNIX_APPEND_CFG)
+
+    return None
 
 
 def detect_ppsspp_ini(config_data: dict) -> str | None:

--- a/linux/raofflineproxy/config.py
+++ b/linux/raofflineproxy/config.py
@@ -64,7 +64,7 @@ def resolve_config_dir() -> Path:
 
 RA_HOST = "https://retroachievements.org"
 RA_MEDIA_HOST = "https://media.retroachievements.org"
-APP_VERSION = os.environ.get("RAOFFLINEPROXY_APP_VERSION") or "1.10.0-alpha8"
+APP_VERSION = os.environ.get("RAOFFLINEPROXY_APP_VERSION") or "1.10.0-alpha9"
 PROXY_UA_TAG = f"RAOfflineProxy/Linux/{APP_VERSION}"
 FALLBACK_USER_AGENT = "RetroArch/1.21.0 (Linux)"
 

--- a/linux/raofflineproxy/lowerdeck.py
+++ b/linux/raofflineproxy/lowerdeck.py
@@ -1,0 +1,134 @@
+"""Chains ROCKNIX's bottom-screen RetroAchievements proxy through ours.
+
+On devices where ROCKNIX detects two connected displays, runemu.sh appends
+`cheevos_custom_host = "http://127.0.0.1:4874"` to the --appendconfig file and
+starts /usr/share/lowerdeck/ra_proxy.py. That layer outranks retroarch.cfg, so
+RetroArch talks to their proxy no matter what we patch, and theirs is a verbatim
+pass-through with no cache — offline it answers 502 with an empty body, which
+surfaces in RetroArch as "RetroAchievements game load failed: Invalid JSON".
+
+Rather than fight for the port, we start their proxy ourselves with its own
+--upstream flag pointed at us:
+
+    RetroArch -> lowerdeck ra_proxy :4874 -> RAOfflineProxy -> retroachievements.org
+
+Their bottom-screen UI still sees every response, and offline its upstream is our
+proxy, which is always reachable. runemu.sh only starts ra_proxy when its pgrep
+finds none running, so ours stays in charge once it is up.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+from .config import proxy_base, running_on_rocknix
+
+LOGGER = logging.getLogger("raofflineproxy")
+
+DUAL_SCREEN_FLAG_FILE = Path("/storage/.config/profile.d/080-dual_screen_mode")
+RA_PROXY_SCRIPT = Path("/usr/share/lowerdeck/ra_proxy.py")
+# Mirrors the pattern runemu.sh greps for, so we can tell whether starting one
+# would collide with an instance ROCKNIX already launched.
+RA_PROXY_PROCESS_PATTERN = r"python3 .*/lowerdeck/ra_proxy\.py"
+
+
+def is_dual_screen() -> bool:
+    try:
+        content = DUAL_SCREEN_FLAG_FILE.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return "DEVICE_HAS_DUAL_SCREEN=true" in content
+
+
+def ra_proxy_running() -> bool:
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", RA_PROXY_PROCESS_PATTERN],
+            capture_output=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+def should_chain_ra_proxy() -> bool:
+    return running_on_rocknix() and is_dual_screen() and RA_PROXY_SCRIPT.exists()
+
+
+def build_ra_proxy_command(config_data: dict) -> list[str]:
+    return [
+        "python3",
+        str(RA_PROXY_SCRIPT),
+        "--upstream",
+        proxy_base(config_data),
+        # Empty needle disables their watchdog. Left on, it calls srv.shutdown()
+        # once RetroArch has been gone for its grace period, and the next game
+        # launch would have ROCKNIX restart it pointed straight at RA again.
+        "--retroarch-process-match",
+        "",
+    ]
+
+
+_chained_process: subprocess.Popen | None = None
+
+
+def ensure_ra_proxy_chained(config_data: dict) -> bool:
+    """Starts ROCKNIX's ra_proxy pointed at us. Returns True if we started it."""
+    global _chained_process
+
+    if not should_chain_ra_proxy():
+        return False
+
+    if ra_proxy_running():
+        LOGGER.info(
+            "lowerdeck ra_proxy already running; leaving it alone "
+            "(it may be pointed straight at RetroAchievements until it exits)"
+        )
+        return False
+
+    command = build_ra_proxy_command(config_data)
+    try:
+        _chained_process = subprocess.Popen(
+            command,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        LOGGER.warning("Failed to start lowerdeck ra_proxy chained through us: %s", exc)
+        return False
+
+    LOGGER.info("Started lowerdeck ra_proxy chained through %s", proxy_base(config_data))
+    return True
+
+
+def stop_ra_proxy_chain() -> bool:
+    """Stops the ra_proxy we started. Returns True if we stopped one.
+
+    Its RetroArch watchdog is disabled so it never exits on its own. Leaving it
+    behind would point RetroArch at a port we no longer serve, breaking
+    achievements outright — worse than the bug this works around. ROCKNIX starts
+    its own unchained instance on the next game launch, so stopping ours simply
+    restores stock behaviour.
+    """
+    global _chained_process
+
+    process = _chained_process
+    _chained_process = None
+    if process is None or process.poll() is not None:
+        return False
+
+    try:
+        process.terminate()
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+    except (OSError, subprocess.SubprocessError) as exc:
+        LOGGER.warning("Failed to stop chained lowerdeck ra_proxy: %s", exc)
+        return False
+
+    LOGGER.info("Stopped chained lowerdeck ra_proxy")
+    return True

--- a/linux/raofflineproxy/proxy_service.py
+++ b/linux/raofflineproxy/proxy_service.py
@@ -27,6 +27,7 @@ from .config import (
     upstream_host,
 )
 from .flusher import flush_pending_awards
+from .lowerdeck import ensure_ra_proxy_chained, stop_ra_proxy_chain
 from .image_cache import (
     IMAGE_PATH_PREFIXES,
     resolve_cached_static_asset,
@@ -1049,6 +1050,7 @@ def run_proxy_service(
 ) -> None:
     storage = Storage()
     migrate_user_case_in_cache_keys(storage)
+    ensure_ra_proxy_chained(config_data)
     server = ProxyRuntimeServer(config_data, storage)
     connectivity_monitor = ConnectivityMonitor(server)
     periodic_refresh = PeriodicRefresh(server)
@@ -1079,5 +1081,6 @@ def run_proxy_service(
     finally:
         connectivity_monitor.stop()
         periodic_refresh.stop()
+        stop_ra_proxy_chain()
         server.server_close()
         storage.close()

--- a/linux/raofflineproxy/retroarch_cfg.py
+++ b/linux/raofflineproxy/retroarch_cfg.py
@@ -99,7 +99,9 @@ def load_retroarch_credentials(cfg_path: str | None) -> dict | None:
     return load_retroarch_password_credentials(cheevos_cfg)
 
 
-def load_retroarch_token_credentials(cfg_path: str | None) -> dict | None:
+def load_retroarch_token_credentials(
+    cfg_path: str | None, last_wins: bool = False
+) -> dict | None:
     if not cfg_path:
         return None
 
@@ -108,14 +110,16 @@ def load_retroarch_token_credentials(cfg_path: str | None) -> dict | None:
         return None
 
     content = target.read_text(encoding="utf-8", errors="replace")
-    user = _extract_config_value(content, USERNAME_KEY)
-    token = _extract_config_value(content, TOKEN_KEY)
+    user = _extract_config_value(content, USERNAME_KEY, last_wins)
+    token = _extract_config_value(content, TOKEN_KEY, last_wins)
     if not user or not token:
         return None
     return {"user": user, "token": token}
 
 
-def load_retroarch_password_credentials(cfg_path: str | None) -> dict | None:
+def load_retroarch_password_credentials(
+    cfg_path: str | None, last_wins: bool = False
+) -> dict | None:
     if not cfg_path:
         return None
 
@@ -124,8 +128,8 @@ def load_retroarch_password_credentials(cfg_path: str | None) -> dict | None:
         return None
 
     content = target.read_text(encoding="utf-8", errors="replace")
-    user = _extract_config_value(content, USERNAME_KEY)
-    password = _extract_config_value(content, PASSWORD_KEY)
+    user = _extract_config_value(content, USERNAME_KEY, last_wins)
+    password = _extract_config_value(content, PASSWORD_KEY, last_wins)
     if not user or not password:
         return None
     return {"user": user, "password": password}
@@ -359,8 +363,14 @@ def enforce_patched_cfg(cfg_path: str, config_data: dict) -> bool:
     return True
 
 
-def _extract_config_value(content: str, key: str) -> str | None:
+def _extract_config_value(content: str, key: str, last: bool = False) -> str | None:
+    """Reads a key. With last=True the final occurrence wins, matching RetroArch.
+
+    ROCKNIX appends to its --appendconfig file without truncating it between game
+    launches, so the same key can appear several times with stale values first.
+    """
     key_pattern = re.compile(rf"^\s*{re.escape(key)}\s*=\s*(.*?)\s*$")
+    found: str | None = None
     for raw_line in content.splitlines():
         match = key_pattern.match(raw_line)
         if match is None:
@@ -368,11 +378,14 @@ def _extract_config_value(content: str, key: str) -> str | None:
 
         value = match.group(1).strip()
         if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
-            return value[1:-1]
-        if value.startswith('"'):
-            return value[1:].strip()
-        return value
-    return None
+            value = value[1:-1]
+        elif value.startswith('"'):
+            value = value[1:].strip()
+
+        if not last:
+            return value
+        found = value
+    return found
 
 
 def _upsert_config_value(content: str, key: str, value: str) -> str:

--- a/linux/raofflineproxy/retroarch_cfg.py
+++ b/linux/raofflineproxy/retroarch_cfg.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 from typing import Optional
 
-from .config import proxy_value
+from .config import detect_rocknix_append_cfg, proxy_value
 from .state import clear_patch_state, load_patch_state, save_patch_state
 
 HOST_KEY = "cheevos_custom_host"
@@ -81,8 +81,11 @@ def detect_hardcore_enabled(content: str) -> bool:
 
 
 def load_retroarch_credentials(cfg_path: str | None) -> dict | None:
-    # Try main cfg first, then the cheevos appendconfig (muOS stores credentials there)
+    # Try main cfg first, then the cheevos appendconfig (muOS stores credentials
+    # there), then ROCKNIX's appendconfig (it strips the cheevos keys out of
+    # retroarch.cfg on every game launch and writes them only into that file).
     cheevos_cfg = str(cheevos_append_cfg_path(cfg_path)) if cfg_path else None
+    rocknix_cfg = detect_rocknix_append_cfg()
 
     token_credentials = load_retroarch_token_credentials(cfg_path)
     if token_credentials is not None:
@@ -92,11 +95,19 @@ def load_retroarch_credentials(cfg_path: str | None) -> dict | None:
     if token_credentials is not None:
         return token_credentials
 
+    token_credentials = load_retroarch_token_credentials(rocknix_cfg, last_wins=True)
+    if token_credentials is not None:
+        return token_credentials
+
     password_credentials = load_retroarch_password_credentials(cfg_path)
     if password_credentials is not None:
         return password_credentials
 
-    return load_retroarch_password_credentials(cheevos_cfg)
+    password_credentials = load_retroarch_password_credentials(cheevos_cfg)
+    if password_credentials is not None:
+        return password_credentials
+
+    return load_retroarch_password_credentials(rocknix_cfg, last_wins=True)
 
 
 def load_retroarch_token_credentials(

--- a/linux/rocknix/build_bundle.sh
+++ b/linux/rocknix/build_bundle.sh
@@ -7,7 +7,7 @@ DIST_DIR="${SCRIPT_DIR}/dist"
 BUILD_DIR="${DIST_DIR}/raofflineproxy-rocknix-bundle"
 APP_DIR="${BUILD_DIR}/app"
 LIB_DIR="${BUILD_DIR}/lib"
-VERSION="${RAOFFLINEPROXY_APP_VERSION:-1.10.0-alpha7-uafix}"
+VERSION="${RAOFFLINEPROXY_APP_VERSION:-1.10.0-alpha8-rocknix}"
 INSTALLER_PATH="${DIST_DIR}/RAOfflineProxy-Rocknix-v${VERSION}-Install.sh"
 TEMP_TARBALL="${DIST_DIR}/.raofflineproxy-rocknix-bundle.tar.gz"
 

--- a/linux/rocknix/build_bundle.sh
+++ b/linux/rocknix/build_bundle.sh
@@ -7,7 +7,7 @@ DIST_DIR="${SCRIPT_DIR}/dist"
 BUILD_DIR="${DIST_DIR}/raofflineproxy-rocknix-bundle"
 APP_DIR="${BUILD_DIR}/app"
 LIB_DIR="${BUILD_DIR}/lib"
-VERSION="${RAOFFLINEPROXY_APP_VERSION:-1.10.0-alpha8-rocknix}"
+VERSION="${RAOFFLINEPROXY_APP_VERSION:-1.10.0-alpha9-rocknix}"
 INSTALLER_PATH="${DIST_DIR}/RAOfflineProxy-Rocknix-v${VERSION}-Install.sh"
 TEMP_TARBALL="${DIST_DIR}/.raofflineproxy-rocknix-bundle.tar.gz"
 

--- a/linux/tests/test_linux_auth.py
+++ b/linux/tests/test_linux_auth.py
@@ -243,5 +243,88 @@ class LinuxAuthTests(unittest.TestCase):
                 store.close()
 
 
+class LinuxRocknixAppendConfigCredentialTests(unittest.TestCase):
+    """ROCKNIX strips credentials out of retroarch.cfg on every game launch and
+    writes them only into its --appendconfig file, so that file has to be read."""
+
+    def test_resolves_password_credentials_from_rocknix_append_config(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            cfg = root / "retroarch.cfg"
+            append_cfg = root / ".retroarch.cfg"
+            # What ROCKNIX leaves behind: the cheevos keys seded out of retroarch.cfg.
+            cfg.write_text('cheevos_enable = "true"\n', encoding="utf-8")
+            append_cfg.write_text(
+                'cheevos_username = "misantronic"\ncheevos_password = "hunter2"\n',
+                encoding="utf-8",
+            )
+            store = storage.Storage(database_path=root / "test.sqlite3")
+            original_login = auth.login_and_cache_token
+            try:
+                auth.login_and_cache_token = (
+                    lambda _store, _cfg, credentials, _ua: {
+                        "user": credentials["user"],
+                        "token": "issued",
+                    }
+                )
+
+                resolved = auth.resolve_credentials(
+                    store,
+                    {"retroarch_cfg": str(cfg), "rocknix_append_cfg": str(append_cfg)},
+                )
+
+                self.assertEqual(resolved, {"user": "misantronic", "token": "issued"})
+            finally:
+                auth.login_and_cache_token = original_login
+                store.close()
+
+    def test_last_occurrence_wins_across_appended_launches(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            cfg = root / "retroarch.cfg"
+            append_cfg = root / ".retroarch.cfg"
+            cfg.write_text("", encoding="utf-8")
+            # ROCKNIX appends without truncating, so stale values sit above current ones.
+            append_cfg.write_text(
+                'cheevos_username = "olduser"\ncheevos_token = "oldtoken"\n'
+                'cheevos_username = "misantronic"\ncheevos_token = "newtoken"\n',
+                encoding="utf-8",
+            )
+            store = storage.Storage(database_path=root / "test.sqlite3")
+            try:
+                resolved = auth.resolve_credentials(
+                    store,
+                    {"retroarch_cfg": str(cfg), "rocknix_append_cfg": str(append_cfg)},
+                )
+
+                self.assertEqual(resolved, {"user": "misantronic", "token": "newtoken"})
+            finally:
+                store.close()
+
+    def test_retroarch_cfg_still_takes_precedence(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            cfg = root / "retroarch.cfg"
+            append_cfg = root / ".retroarch.cfg"
+            cfg.write_text(
+                'cheevos_username = "fromcfg"\ncheevos_token = "cfgtoken"\n',
+                encoding="utf-8",
+            )
+            append_cfg.write_text(
+                'cheevos_username = "fromappend"\ncheevos_token = "appendtoken"\n',
+                encoding="utf-8",
+            )
+            store = storage.Storage(database_path=root / "test.sqlite3")
+            try:
+                resolved = auth.resolve_credentials(
+                    store,
+                    {"retroarch_cfg": str(cfg), "rocknix_append_cfg": str(append_cfg)},
+                )
+
+                self.assertEqual(resolved, {"user": "fromcfg", "token": "cfgtoken"})
+            finally:
+                store.close()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/linux/tests/test_linux_lowerdeck.py
+++ b/linux/tests/test_linux_lowerdeck.py
@@ -1,0 +1,102 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from linux.raofflineproxy import lowerdeck
+
+
+class LinuxLowerdeckTests(unittest.TestCase):
+    def _flag_file(self, root: Path, content: str) -> Path:
+        flag = root / "080-dual_screen_mode"
+        flag.write_text(content, encoding="utf-8")
+        return flag
+
+    def test_is_dual_screen_true_when_flag_set(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            flag = self._flag_file(Path(temp_dir), "DEVICE_HAS_DUAL_SCREEN=true\n")
+            with mock.patch.object(lowerdeck, "DUAL_SCREEN_FLAG_FILE", flag):
+                self.assertTrue(lowerdeck.is_dual_screen())
+
+    def test_is_dual_screen_false_for_single_screen_device(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            flag = self._flag_file(Path(temp_dir), "DEVICE_HAS_DUAL_SCREEN=false\n")
+            with mock.patch.object(lowerdeck, "DUAL_SCREEN_FLAG_FILE", flag):
+                self.assertFalse(lowerdeck.is_dual_screen())
+
+    def test_is_dual_screen_false_when_flag_file_missing(self) -> None:
+        missing = Path("/nonexistent/080-dual_screen_mode")
+        with mock.patch.object(lowerdeck, "DUAL_SCREEN_FLAG_FILE", missing):
+            self.assertFalse(lowerdeck.is_dual_screen())
+
+    def test_command_points_upstream_at_our_proxy_and_disables_watchdog(self) -> None:
+        command = lowerdeck.build_ra_proxy_command({"proxy_port": 8080})
+
+        self.assertIn("--upstream", command)
+        self.assertEqual(command[command.index("--upstream") + 1], "http://127.0.0.1:8080")
+        # Empty needle is what disables their RetroArch watchdog; without it the
+        # proxy shuts itself down and ROCKNIX restarts it pointed at RA directly.
+        self.assertEqual(command[command.index("--retroarch-process-match") + 1], "")
+
+    def test_command_honours_a_custom_proxy_port(self) -> None:
+        command = lowerdeck.build_ra_proxy_command({"proxy_port": 9999})
+
+        self.assertEqual(command[command.index("--upstream") + 1], "http://127.0.0.1:9999")
+
+    def test_does_not_start_on_single_screen_devices(self) -> None:
+        with mock.patch.object(lowerdeck, "should_chain_ra_proxy", return_value=False):
+            with mock.patch.object(lowerdeck.subprocess, "Popen") as popen:
+                self.assertFalse(lowerdeck.ensure_ra_proxy_chained({}))
+                popen.assert_not_called()
+
+    def test_does_not_start_a_second_instance(self) -> None:
+        with mock.patch.object(lowerdeck, "should_chain_ra_proxy", return_value=True):
+            with mock.patch.object(lowerdeck, "ra_proxy_running", return_value=True):
+                with mock.patch.object(lowerdeck.subprocess, "Popen") as popen:
+                    self.assertFalse(lowerdeck.ensure_ra_proxy_chained({}))
+                    popen.assert_not_called()
+
+    def test_starts_chained_proxy_when_none_is_running(self) -> None:
+        with mock.patch.object(lowerdeck, "should_chain_ra_proxy", return_value=True):
+            with mock.patch.object(lowerdeck, "ra_proxy_running", return_value=False):
+                with mock.patch.object(lowerdeck.subprocess, "Popen") as popen:
+                    self.assertTrue(lowerdeck.ensure_ra_proxy_chained({"proxy_port": 8080}))
+                    popen.assert_called_once()
+                    command = popen.call_args[0][0]
+                    self.assertEqual(command[command.index("--upstream") + 1], "http://127.0.0.1:8080")
+
+    def test_stop_terminates_the_proxy_we_started(self) -> None:
+        process = mock.Mock()
+        process.poll.return_value = None
+        with mock.patch.object(lowerdeck, "_chained_process", process):
+            self.assertTrue(lowerdeck.stop_ra_proxy_chain())
+            process.terminate.assert_called_once()
+
+    def test_stop_kills_a_proxy_that_ignores_terminate(self) -> None:
+        process = mock.Mock()
+        process.poll.return_value = None
+        process.wait.side_effect = lowerdeck.subprocess.TimeoutExpired("ra_proxy", 5)
+        with mock.patch.object(lowerdeck, "_chained_process", process):
+            lowerdeck.stop_ra_proxy_chain()
+            process.kill.assert_called_once()
+
+    def test_stop_is_a_noop_when_we_started_nothing(self) -> None:
+        with mock.patch.object(lowerdeck, "_chained_process", None):
+            self.assertFalse(lowerdeck.stop_ra_proxy_chain())
+
+    def test_stop_does_not_touch_a_proxy_that_already_exited(self) -> None:
+        process = mock.Mock()
+        process.poll.return_value = 0
+        with mock.patch.object(lowerdeck, "_chained_process", process):
+            self.assertFalse(lowerdeck.stop_ra_proxy_chain())
+            process.terminate.assert_not_called()
+
+    def test_start_failure_is_not_fatal(self) -> None:
+        with mock.patch.object(lowerdeck, "should_chain_ra_proxy", return_value=True):
+            with mock.patch.object(lowerdeck, "ra_proxy_running", return_value=False):
+                with mock.patch.object(lowerdeck.subprocess, "Popen", side_effect=OSError("boom")):
+                    self.assertFalse(lowerdeck.ensure_ra_proxy_chained({}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/linux/tests/test_linux_retroarch_cfg.py
+++ b/linux/tests/test_linux_retroarch_cfg.py
@@ -1,5 +1,6 @@
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 from linux.raofflineproxy import retroarch_cfg
@@ -129,3 +130,41 @@ class UpsertEmptyValueRegressionTests(unittest.TestCase):
         result = retroarch_cfg._remove_orphan_boolean_lines(content)
         self.assertNotIn('""', result)
         self.assertIn("input_libretro_device_p4 = 1", result)
+
+
+class LinuxRocknixMenuCredentialTests(unittest.TestCase):
+    """The menu's status line reads credentials through load_retroarch_credentials,
+    a separate path from auth.resolve_credentials. Both have to know about
+    ROCKNIX's appendconfig or the menu reports LOGIN REQUIRED while the service
+    is perfectly able to log in."""
+
+    def test_falls_back_to_rocknix_append_config(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            cfg = root / "retroarch.cfg"
+            append_cfg = root / ".retroarch.cfg"
+            # What a real ROCKNIX device looks like: a token with no username in
+            # retroarch.cfg (unusable on its own), credentials in the appendconfig.
+            cfg.write_text('cheevos_token = "orphan"\n', encoding="utf-8")
+            append_cfg.write_text(
+                'cheevos_username = "misantronic"\ncheevos_password = "hunter2"\n',
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(
+                retroarch_cfg, "detect_rocknix_append_cfg", return_value=str(append_cfg)
+            ):
+                credentials = retroarch_cfg.load_retroarch_credentials(str(cfg))
+
+            self.assertIsNotNone(credentials)
+            self.assertEqual(credentials["user"], "misantronic")
+
+    def test_orphan_token_without_username_is_not_credentials(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cfg = Path(temp_dir) / "retroarch.cfg"
+            cfg.write_text('cheevos_token = "orphan"\n', encoding="utf-8")
+
+            with mock.patch.object(
+                retroarch_cfg, "detect_rocknix_append_cfg", return_value=None
+            ):
+                self.assertIsNone(retroarch_cfg.load_retroarch_credentials(str(cfg)))


### PR DESCRIPTION
Fixes #92. Fixes #95.

Both issues come from the same fact: on ROCKNIX, `retroarch.cfg` is not the source of truth. RetroArch is launched as `--config .../retroarch.cfg --appendconfig /tmp/.retroarch.cfg`, and the append layer outranks the main config.

## #92 — "Login Required"

`setsettings.sh` runs on every game launch and, for each key it manages, seds it out of `retroarch.cfg` and writes the live value into the appendconfig instead. `cheevos_username` and `cheevos_password` are managed that way; `cheevos_token` and `cheevos_custom_host` are not, which is why the symptom only appears on devices without a persisted token.

The reporter's device showed the failure exactly: `retroarch.cfg` held a `cheevos_token` with no `cheevos_username` (unusable, since both are required), while the username/password pair sat in the appendconfig we never read.

Both credential paths now consult it:

- `auth.resolve_credentials` — the service path, used for caching and awards
- `retroarch_cfg.load_retroarch_credentials` — the menu path behind `is_logged_in`, which draws the status line

Missing the second one is what made alpha8 still report "Login Required" while the service could log in perfectly well. That path had no test coverage at all; it does now.

The appendconfig is written to without truncation between launches, so it is parsed last-wins to match RetroArch.

## #95 — "Invalid JSON" offline

On dual-screen devices `runemu.sh` appends `cheevos_custom_host = "http://127.0.0.1:4874"` and starts `/usr/share/lowerdeck/ra_proxy.py`, ROCKNIX's own proxy for the bottom-screen achievement UI. It is a verbatim pass-through with no cache, and offline it answers 502 with an empty body — which RetroArch reports as "Invalid JSON". Because it arrives via the appendconfig, our patched host can never win.

Rather than compete for the port, we start their script ourselves using its own documented flags:

    RetroArch -> lowerdeck ra_proxy :4874 -> RAOfflineProxy -> retroachievements.org

`runemu.sh` only starts an instance when its `pgrep` finds none, so ours stays in charge. `--retroarch-process-match ""` disables their watchdog, which would otherwise shut our instance down and let ROCKNIX restart it pointed straight at RetroAchievements. Because that watchdog is off, we stop the child on service shutdown — leaving it behind would point RetroArch at a dead port and break achievements outright, which is worse than the bug.

Every gate fails closed: nothing happens off ROCKNIX, on single-screen devices, or when the script is absent.

Note that `DEVICE_HAS_DUAL_SCREEN` is not a device whitelist — ROCKNIX counts connected connectors with `modetest` at boot, so a single-screen handheld booted with HDMI attached also qualifies.

## Verification

Confirmed on an AYN Thor (ROCKNIX 20260801) over SSH:

    Started lowerdeck ra_proxy chained through http://127.0.0.1:8080
    Request: GET /dorequest.php?r=gameid&m=b259... online=True

A request sent to their proxy on 4874 came out of our service log. Then confirmed on a clean install: credentials resolved, login and status correct, game cached, and offline play working.

The reporter independently confirmed both fixes on the same hardware, and that the bottom screen still displays achievements — so chaining preserves ROCKNIX's feature rather than displacing it.

18 new tests, 439 passing.