### PR TITLE
Open the proxy port before the app finishes starting at boot (#86)

### DIFF
--- a/linux/knulli/scripts/launcher-raofflineproxy
+++ b/linux/knulli/scripts/launcher-raofflineproxy
@@ -15,4 +15,12 @@ fi
 
 export PYTHONPATH="${PYTHONPATH_ENTRIES}${PYTHONPATH:+:${PYTHONPATH}}"
 
+case "${1:-}" in
+  boot-reconcile | start-proxy)
+    # raofflineproxy.boot opens the proxy port before loading the rest of the
+    # package, so an emulator started alongside this hook is not refused.
+    exec /usr/bin/python3 -m raofflineproxy.boot "$@"
+    ;;
+esac
+
 exec /usr/bin/python3 -m raofflineproxy.main "$@"

--- a/linux/muos/launch.sh
+++ b/linux/muos/launch.sh
@@ -12,7 +12,10 @@ PYTHON_STDERR_FILE="${DATA_DIR}/python-stderr.log"
 
 mkdir -p "$DATA_DIR"
 
-# Install icon into every theme on each run (needed for Applications menu)
+# Install icon into every theme (needed for Applications menu). Only run this on
+# the menu path: it walks the whole theme tree on the SD card, and doing that in
+# the boot hook delays the proxy socket past RetroArch's achievement login when
+# muOS is configured to resume content at boot.
 _install_icon() {
     ICON_SRC="${BASE_DIR}/raofflineproxy.png"
     [ -f "$ICON_SRC" ] || return 0
@@ -21,7 +24,6 @@ _install_icon() {
         cp "$ICON_SRC" "${THEME_DIR}/raofflineproxy.png"
     done
 }
-_install_icon
 
 export HOME="/root"
 export XDG_CONFIG_HOME="/root/.config"
@@ -45,6 +47,7 @@ if [ "$#" -eq 0 ]; then
 fi
 
 if [ "$1" = "menu-sdl" ]; then
+    _install_icon
     /usr/bin/python -m raofflineproxy.main ensure-boot-hook >/dev/null 2>&1 || true
 fi
 

--- a/linux/muos/launch.sh
+++ b/linux/muos/launch.sh
@@ -36,14 +36,20 @@ export LD_LIBRARY_PATH="${PYGAME_LIBS_DIR}:/usr/lib/gl4es:/opt/muos/frontend/lib
 cd "$BASE_DIR"
 
 printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "launch.sh args: $*" >>"$LOG_FILE"
-printf '%s\n' "BASE_DIR=$BASE_DIR" >>"$LOG_FILE"
-printf '%s\n' "SDL_VIDEODRIVER=$SDL_VIDEODRIVER" >>"$LOG_FILE"
-printf '%s\n' "PYTHONPATH=$PYTHONPATH" >>"$LOG_FILE"
-printf '%s\n' "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >>"$LOG_FILE"
-printf 'PYTHON_VERSION=%s\n' "$(/usr/bin/python --version 2>&1)" >>"$LOG_FILE"
-
 if [ "$#" -eq 0 ]; then
     set -- menu-sdl
+fi
+
+# Everything not needed to get the proxy port open stays off the boot-reconcile
+# path: muOS runs this hook in parallel with launching the last played game, so
+# time spent here is time RetroArch can lose its achievement login to a closed
+# port.
+if [ "$1" != "boot-reconcile" ]; then
+    printf '%s\n' "BASE_DIR=$BASE_DIR" >>"$LOG_FILE"
+    printf '%s\n' "SDL_VIDEODRIVER=$SDL_VIDEODRIVER" >>"$LOG_FILE"
+    printf '%s\n' "PYTHONPATH=$PYTHONPATH" >>"$LOG_FILE"
+    printf '%s\n' "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >>"$LOG_FILE"
+    printf 'PYTHON_VERSION=%s\n' "$(/usr/bin/python --version 2>&1)" >>"$LOG_FILE"
 fi
 
 if [ "$1" = "menu-sdl" ]; then
@@ -54,6 +60,9 @@ fi
 case "$1" in
     menu-sdl)
         exec /usr/bin/python -m raofflineproxy.main "$@" >>"$PYTHON_STDOUT_FILE" 2>>"$PYTHON_STDERR_FILE"
+        ;;
+    boot-reconcile | start-proxy)
+        exec /usr/bin/python -m raofflineproxy.boot "$@"
         ;;
     *)
         exec /usr/bin/python -m raofflineproxy.main "$@"

--- a/linux/onion/app/RAOfflineProxy/common.sh
+++ b/linux/onion/app/RAOfflineProxy/common.sh
@@ -153,7 +153,17 @@ run_backend() {
 run_backend_raw() {
     python_bin="$1"
     shift
-    "$python_bin" -m raofflineproxy.main "$@"
+    case "${1:-}" in
+        boot-reconcile | start-proxy)
+            # raofflineproxy.boot opens the proxy port before loading the rest
+            # of the package, so an emulator started alongside this hook is not
+            # refused.
+            "$python_bin" -m raofflineproxy.boot "$@"
+            ;;
+        *)
+            "$python_bin" -m raofflineproxy.main "$@"
+            ;;
+    esac
 }
 
 log_path() {

--- a/linux/raofflineproxy/boot.py
+++ b/linux/raofflineproxy/boot.py
@@ -1,0 +1,79 @@
+"""Boot entrypoint that opens the proxy port before anything else runs.
+
+Importing the full package and starting the service process costs several
+seconds on handheld hardware. muOS launches the last played content in parallel
+with its user-init scripts, so the emulator can reach its RetroAchievements
+login before the service is up — and a refused connection makes rcheevos
+disable achievements for the whole session.
+
+Binding here, with only the stdlib loaded, means the port is listening within a
+fraction of that time. Connections that arrive before the service is ready sit
+in the accept queue instead of being refused. The listening socket is handed to
+the service process through LISTEN_FD_ENV.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+
+LISTEN_FD_ENV = "RAOFFLINEPROXY_LISTEN_FD"
+LISTEN_BACKLOG = 32
+PREBIND_COMMANDS = ("boot-reconcile", "start-proxy")
+
+
+def prebind_listen_socket() -> socket.socket | None:
+    from .config import load_config, proxy_host, proxy_port
+
+    config_data = load_config()
+    address = (proxy_host(config_data), proxy_port(config_data))
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(address)
+        sock.listen(LISTEN_BACKLOG)
+    except OSError:
+        # Most likely a service is already running and holding the port.
+        sock.close()
+        return None
+
+    sock.set_inheritable(True)
+    return sock
+
+
+def adopt_listen_socket() -> socket.socket | None:
+    """Reclaim the socket handed over by the boot entrypoint, if any."""
+    raw_fd = os.environ.pop(LISTEN_FD_ENV, None)
+    if not raw_fd:
+        return None
+
+    try:
+        fd = int(raw_fd)
+    except ValueError:
+        return None
+
+    try:
+        return socket.socket(socket.AF_INET, socket.SOCK_STREAM, fileno=fd)
+    except OSError:
+        return None
+
+
+def main() -> None:
+    command = sys.argv[1] if len(sys.argv) > 1 else ""
+    listen_socket = prebind_listen_socket() if command in PREBIND_COMMANDS else None
+    if listen_socket is not None:
+        os.environ[LISTEN_FD_ENV] = str(listen_socket.fileno())
+
+    from .main import main as run_main
+
+    try:
+        run_main()
+    finally:
+        if listen_socket is not None:
+            listen_socket.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/linux/raofflineproxy/log_uploader.py
+++ b/linux/raofflineproxy/log_uploader.py
@@ -60,7 +60,17 @@ def _log_file_paths() -> list[Path]:
     # menu-sdl.log is a separate log written by the pygame menu process itself
     # (key logger output, controller calibration, crashes) — not covered by service.log.
     menu_sdl_log = config.CONFIG_DIR / "menu-sdl.log"
-    return [backup, config.LOG_FILE, menu_sdl_log, config.UPDATE_STATUS_FILE, config.STATUS_FILE]
+    # launch.log (muOS only) timestamps every launcher invocation, including the
+    # boot hook — the only way to see how late the service starts at boot.
+    launch_log = config.CONFIG_DIR / "launch.log"
+    return [
+        backup,
+        config.LOG_FILE,
+        menu_sdl_log,
+        launch_log,
+        config.UPDATE_STATUS_FILE,
+        config.STATUS_FILE,
+    ]
 
 
 def _redact_storage_json(text: str) -> str:

--- a/linux/raofflineproxy/main.py
+++ b/linux/raofflineproxy/main.py
@@ -97,6 +97,11 @@ def _apply_proxy(config_data: dict, cfg_path: str) -> list[str]:
     output: list[str] = []
 
     remove_stale_hook()
+    # Spawn the service first so its interpreter starts up (and binds the proxy
+    # port) while the config patching below runs. At boot on devices that resume
+    # content automatically, the emulator's achievement login can arrive within
+    # seconds of this hook being scheduled.
+    service = start_service_process(config_data)
     result = patch_retroarch_cfg(cfg_path, config_data)
     enforce_patched_cfg(cfg_path, config_data)
     batocera = patch_batocera_conf(config_data)
@@ -107,7 +112,6 @@ def _apply_proxy(config_data: dict, cfg_path: str) -> list[str]:
     store_ppsspp_previous(patch_state, ppsspp)
     store_dolphin_previous(patch_state, dolphin)
     save_patch_state(patch_state)
-    service = start_service_process(config_data)
 
     if result["already_patched"]:
         output.append("retroarch.cfg already patched")

--- a/linux/raofflineproxy/proxy_service.py
+++ b/linux/raofflineproxy/proxy_service.py
@@ -15,6 +15,7 @@ from urllib.parse import urlsplit
 
 from . import cache_keys, log_uploader, storage_corruption
 from .auth import resolve_credentials
+from .boot import adopt_listen_socket
 from .award_signing import sign_award
 from .config import (
     DATABASE_FILE,
@@ -272,7 +273,16 @@ class ProxyRuntimeServer(ThreadingTCPServer):
         self.pending_award_lock = threading.Lock()
         host = proxy_host(self.config_data)
         port = proxy_port(self.config_data)
-        super().__init__((host, port), ProxyRequestHandler)
+        inherited = adopt_listen_socket()
+        super().__init__(
+            (host, port),
+            ProxyRequestHandler,
+            bind_and_activate=inherited is None,
+        )
+        if inherited is not None:
+            self.socket.close()
+            self.socket = inherited
+            self.server_address = self.socket.getsockname()
 
     def _proxy_base_url(self) -> str:
         cfg = getattr(self, "config_data", {})

--- a/linux/raofflineproxy/proxy_service.py
+++ b/linux/raofflineproxy/proxy_service.py
@@ -1049,13 +1049,29 @@ def run_proxy_service(
     config_data: dict, stop_event: threading.Event | None = None
 ) -> None:
     storage = Storage()
-    migrate_user_case_in_cache_keys(storage)
-    ensure_ra_proxy_chained(config_data)
+    # Bind the listening port before any other startup work: on boot-to-game
+    # devices the emulator can reach its RetroAchievements login before the
+    # service is fully up, and a refused connection disables achievements for
+    # the whole session. Once the socket listens, those connections queue.
     server = ProxyRuntimeServer(config_data, storage)
+    LOGGER.info(
+        "Proxy listening host=%s port=%s",
+        proxy_host(config_data),
+        proxy_port(config_data),
+    )
+    ensure_ra_proxy_chained(config_data)
     connectivity_monitor = ConnectivityMonitor(server)
     periodic_refresh = PeriodicRefresh(server)
 
     try:
+        serving_thread = threading.Thread(
+            target=server.serve_forever,
+            kwargs={"poll_interval": 0.5},
+            daemon=True,
+        )
+        serving_thread.start()
+
+        migrate_user_case_in_cache_keys(storage)
         initial_online = server.refresh_reachability(force_probe=True)
         save_online_state(initial_online)
         if initial_online:
@@ -1065,17 +1081,11 @@ def run_proxy_service(
         periodic_refresh.start()
 
         if stop_event is None:
-            server.serve_forever(poll_interval=0.5)
-            return
+            serving_thread.join()
+        else:
+            while not stop_event.wait(0.5):
+                continue
 
-        serving_thread = threading.Thread(
-            target=server.serve_forever,
-            kwargs={"poll_interval": 0.5},
-            daemon=True,
-        )
-        serving_thread.start()
-        while not stop_event.wait(0.5):
-            continue
         server.shutdown()
         serving_thread.join(timeout=5)
     finally:

--- a/linux/raofflineproxy/service.py
+++ b/linux/raofflineproxy/service.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import time
 
+from .boot import LISTEN_FD_ENV
 from .config import CONFIG_DIR, DATABASE_FILE, LOG_FILE, configure_logging
 from .proxy_service import run_proxy_service
 from .state import (
@@ -215,6 +216,15 @@ def start_service_process(config_data: dict) -> dict:
         clear_service_status()
 
     LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    listen_fd = os.environ.get(LISTEN_FD_ENV)
+    pass_fds: tuple[int, ...] = ()
+    env = None
+    if listen_fd:
+        # Hand the already-listening socket from the boot entrypoint to the
+        # service so the port never closes between the two processes.
+        pass_fds = (int(listen_fd),)
+        env = {**os.environ, LISTEN_FD_ENV: listen_fd}
+
     with LOG_FILE.open("a", encoding="utf-8") as log_handle:
         process = subprocess.Popen(
             [sys.executable, "-m", "raofflineproxy.main", "run-service"],
@@ -223,6 +233,8 @@ def start_service_process(config_data: dict) -> dict:
             stdin=subprocess.DEVNULL,
             close_fds=True,
             start_new_session=True,
+            pass_fds=pass_fds,
+            env=env,
         )
 
     save_running_service_state(process.pid, config_data)

--- a/linux/rocknix/scripts/launcher-raofflineproxy
+++ b/linux/rocknix/scripts/launcher-raofflineproxy
@@ -9,4 +9,12 @@ export PATH="/usr/local/bin:/usr/bin:/bin:${BASE_DIR}/bin:${PATH:-}"
 export LD_LIBRARY_PATH="${BASE_DIR}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 export PYTHONPATH="${BASE_DIR}/app:${BASE_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
 
+case "${1:-}" in
+  boot-reconcile | start-proxy)
+    # raofflineproxy.boot opens the proxy port before loading the rest of the
+    # package, so an emulator started alongside this hook is not refused.
+    exec /usr/bin/python3 -m raofflineproxy.boot "$@"
+    ;;
+esac
+
 exec /usr/bin/python3 -m raofflineproxy.main "$@"

--- a/linux/tests/test_linux_boot_prebind.py
+++ b/linux/tests/test_linux_boot_prebind.py
@@ -1,0 +1,114 @@
+import os
+import socket
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from linux.raofflineproxy import boot, proxy_service, storage
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+class PrebindListenSocketTests(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ.pop(boot.LISTEN_FD_ENV, None)
+        self.addCleanup(os.environ.pop, boot.LISTEN_FD_ENV, None)
+
+    def test_prebound_socket_accepts_connections_before_the_service_runs(self) -> None:
+        port = _free_port()
+        with mock.patch(
+            "linux.raofflineproxy.config.proxy_port", return_value=port
+        ), mock.patch(
+            "linux.raofflineproxy.config.proxy_host", return_value="127.0.0.1"
+        ), mock.patch(
+            "linux.raofflineproxy.config.load_config", return_value={}
+        ):
+            listen_socket = boot.prebind_listen_socket()
+
+        self.assertIsNotNone(listen_socket)
+        assert listen_socket is not None
+        self.addCleanup(listen_socket.close)
+
+        # Nothing is accepting yet — the connection must still be established
+        # rather than refused, which is what keeps rcheevos from giving up.
+        with socket.create_connection(("127.0.0.1", port), timeout=2) as client:
+            connection, _ = listen_socket.accept()
+            connection.close()
+            self.assertIsNotNone(client)
+
+    def test_prebind_returns_none_when_the_port_is_taken(self) -> None:
+        port = _free_port()
+        holder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        holder.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        holder.bind(("127.0.0.1", port))
+        holder.listen(1)
+        self.addCleanup(holder.close)
+
+        with mock.patch(
+            "linux.raofflineproxy.config.proxy_port", return_value=port
+        ), mock.patch(
+            "linux.raofflineproxy.config.proxy_host", return_value="127.0.0.1"
+        ), mock.patch(
+            "linux.raofflineproxy.config.load_config", return_value={}
+        ):
+            self.assertIsNone(boot.prebind_listen_socket())
+
+    def test_adopt_returns_the_same_socket_and_clears_the_environment(self) -> None:
+        port = _free_port()
+        listen_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listen_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listen_socket.bind(("127.0.0.1", port))
+        listen_socket.listen(1)
+        listen_socket.set_inheritable(True)
+        self.addCleanup(listen_socket.close)
+
+        os.environ[boot.LISTEN_FD_ENV] = str(listen_socket.fileno())
+        adopted = boot.adopt_listen_socket()
+
+        self.assertIsNotNone(adopted)
+        assert adopted is not None
+        self.addCleanup(adopted.detach)
+        self.assertEqual(adopted.getsockname()[1], port)
+        self.assertNotIn(boot.LISTEN_FD_ENV, os.environ)
+
+    def test_adopt_without_a_handover_returns_none(self) -> None:
+        self.assertIsNone(boot.adopt_listen_socket())
+
+    def test_adopt_ignores_a_malformed_handover(self) -> None:
+        os.environ[boot.LISTEN_FD_ENV] = "not-a-number"
+        self.assertIsNone(boot.adopt_listen_socket())
+
+    def test_server_serves_on_the_handed_over_socket(self) -> None:
+        port = _free_port()
+        listen_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listen_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listen_socket.bind(("127.0.0.1", port))
+        listen_socket.listen(1)
+        listen_socket.set_inheritable(True)
+        os.environ[boot.LISTEN_FD_ENV] = str(listen_socket.fileno())
+        # The server takes ownership of the descriptor from here on.
+        listen_socket.detach()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = storage.Storage(database_path=Path(temp_dir) / "test.sqlite3")
+            # A different port in the config proves the handed-over socket is
+            # adopted rather than a fresh one being bound.
+            server = proxy_service.ProxyRuntimeServer(
+                {"proxy_port": _free_port()}, store
+            )
+            try:
+                self.assertEqual(server.socket.getsockname()[1], port)
+                self.assertEqual(server.server_address[1], port)
+                self.assertNotIn(boot.LISTEN_FD_ENV, os.environ)
+            finally:
+                server.server_close()
+                store.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #86.

On muOS with "resume content at boot", the last played game is launched in parallel with the user-init scripts that start RAOfflineProxy. RetroArch reached its RetroAchievements login before the proxy had bound its port, the connection was refused, and rcheevos disabled achievements for the whole session — which is why relaunching the game fixed it.

The proxy takes about 10 seconds to come up on this hardware (two Python interpreter startups plus package imports off SD), so winning that race by being faster was not realistic. Instead the port is now opened first and the rest follows.

## Changes

- `raofflineproxy/boot.py`: a boot entrypoint that imports only `socket`/`os`, binds and listens on the proxy port, then loads the rest of the package. Connections arriving before the service is ready queue in the accept backlog instead of being refused. The listening socket is handed to the service process by file descriptor so the port never closes in between.
- `service.py`: passes that descriptor to the spawned service via `pass_fds` and the environment.
- `proxy_service.py`: the server adopts the handed-over socket instead of binding its own, and falls back to a normal bind when there is none (menu "Start proxy", tests). Binding also moved ahead of the cache-key migration and the reachability probe.
- Launchers for muOS, Knulli, ROCKNIX and Onion route `boot-reconcile`/`start-proxy` to the new entrypoint. muOS additionally skips its diagnostic log block on the boot path, which cost an extra interpreter start.
- `log_uploader.py`: muOS `launch.log` is included in support bundles, which is what made the boot timing measurable in the first place.

## Verification

Confirmed by the reporter on an RG35XX-SP, and the log shows the mechanism rather than just the outcome. Across two boots, RetroArch's login was served 9 ms and 10 ms after the service began accepting — the connection had been waiting in the queue the whole time the app was starting.

Tests: `python3 -m pytest linux/tests/` passes, including six new tests covering the pre-bind, the hand-off, and the fallback.