### PR TITLE
Start on KNULLI when RetroArch's cfg has not been generated yet (#111)

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -134,6 +134,12 @@ Default detection order for `retroarch.cfg`:
 6. `/storage/.config/retroarch/retroarch.cfg`
 7. `~/.config/retroarch/retroarch.cfg`
 
+On KNULLI/Batocera, `retroarchcustom.cfg` is generated at the first libretro
+launch, so none of candidates 2-5 exist on a freshly flashed device. Detection
+then keeps candidate 2 as the path, and starting the proxy skips the missing
+file instead of failing: `knulli.conf`/`batocera.conf` carries the host override
+on its own, and configgen rebuilds the cfg from it at every launch.
+
 Saved patch state is stored in:
 
 ```text

--- a/linux/raofflineproxy/config.py
+++ b/linux/raofflineproxy/config.py
@@ -4,17 +4,31 @@ import json
 import logging
 import logging.handlers
 import os
+from collections.abc import Callable
 from pathlib import Path
 
 
 DEFAULT_ONION_APP_DIR = Path("/mnt/SDCARD/App/RAOfflineProxy")
 DEFAULT_ONION_STARTUP_SCRIPT = Path("/mnt/SDCARD/.tmp_update/startup/raofflineproxy.sh")
+SDCARD_RETROARCH_CFG_CANDIDATES = (
+    Path("/mnt/SDCARD/RetroArch/.retroarch/retroarch.cfg"),
+)
 DEFAULT_MUOS_APPLICATION_DIR = Path("/run/muos/storage/application/RAOfflineProxy")
 DEFAULT_MUOS_INIT_DIR = Path("/run/muos/storage/init")
 DEFAULT_MUOS_RETROARCH_CFG = Path("/opt/muos/share/info/config/retroarch.cfg")
 MUOS_USER_INIT_CONFIG = Path("/opt/muos/config/settings/advanced/user_init")
 DEFAULT_BATOCERA_CONF = Path("/userdata/system/batocera.conf")
 DEFAULT_KNULLI_CONF = Path("/userdata/system/knulli.conf")
+# Knulli/Batocera generate retroarchcustom.cfg at the first libretro launch, so a
+# freshly flashed device has none of these yet. Keep the canonical path as the
+# fallback: /userdata already established the platform, and falling
+# through to the other platforms' branches would hand back a path Knulli never uses.
+KNULLI_RETROARCH_CFG_CANDIDATES = (
+    Path("/userdata/system/configs/retroarch/retroarchcustom.cfg"),
+    Path("/userdata/system/configs/retroarch/retroarch.cfg"),
+    Path("/userdata/system/.config/retroarch/retroarchcustom.cfg"),
+    Path("/userdata/system/.config/retroarch/retroarch.cfg"),
+)
 DEFAULT_ROCKNIX_RETROARCH_CFG = Path("/storage/.config/retroarch/retroarch.cfg")
 DEFAULT_ROCKNIX_CONFIG_DIR = Path("/storage/.config/raofflineproxy")
 DEFAULT_ROCKNIX_PPSSPP_INI = Path("/storage/.config/ppsspp/PSP/SYSTEM/ppsspp.ini")
@@ -185,34 +199,38 @@ def detect_batocera_conf(config_data: dict) -> str | None:
     return None
 
 
+def _retroarch_cfg_lookup() -> tuple[tuple[Callable[[], bool], tuple[Path, ...]], ...]:
+    """Platform gate paired with that platform's cfg candidates, most specific first.
+
+    Built per call so the module globals stay late-bound. Candidates are scoped to
+    their own platform on purpose: several firmwares share a card and leave stale
+    folders behind, so a single flat "first path that exists wins" list would hand
+    back another firmware's config. Each platform's first candidate doubles as its
+    fallback, which is what a device that has not generated its cfg yet gets.
+    """
+    return (
+        (lambda: DEFAULT_MUOS_RETROARCH_CFG.exists(), (DEFAULT_MUOS_RETROARCH_CFG,)),
+        (lambda: Path("/userdata").exists(), tuple(KNULLI_RETROARCH_CFG_CANDIDATES)),
+        (
+            lambda: running_on_rocknix() or Path("/storage").exists(),
+            (DEFAULT_ROCKNIX_RETROARCH_CFG,),
+        ),
+        (lambda: Path("/mnt/SDCARD").exists(), tuple(SDCARD_RETROARCH_CFG_CANDIDATES)),
+    )
+
+
 def detect_retroarch_cfg() -> str:
     env_override = os.environ.get("RAOFFLINEPROXY_RETROARCH_CFG")
     if env_override:
         return env_override
 
-    if DEFAULT_MUOS_RETROARCH_CFG.exists():
-        return str(DEFAULT_MUOS_RETROARCH_CFG)
-
-    if Path("/userdata").exists():
-        return str(Path("/userdata/system/configs/retroarch/retroarchcustom.cfg"))
-
-    if running_on_rocknix():
-        return str(DEFAULT_ROCKNIX_RETROARCH_CFG)
-
-    candidates = [
-        Path("/mnt/SDCARD/RetroArch/.retroarch/retroarch.cfg"),
-        Path.home() / ".config" / "retroarch" / "retroarch.cfg",
-    ]
-
-    for candidate in candidates:
-        if candidate.exists():
-            return str(candidate)
-
-    if Path("/storage").exists():
-        return str(Path("/storage/.config/retroarch/retroarch.cfg"))
-
-    if Path("/mnt/SDCARD").exists():
-        return str(Path("/mnt/SDCARD/RetroArch/.retroarch/retroarch.cfg"))
+    for platform_matches, candidates in _retroarch_cfg_lookup():
+        if not platform_matches() or not candidates:
+            continue
+        for candidate in candidates:
+            if candidate.exists():
+                return str(candidate)
+        return str(candidates[0])
 
     return str(Path.home() / ".config" / "retroarch" / "retroarch.cfg")
 

--- a/linux/raofflineproxy/main.py
+++ b/linux/raofflineproxy/main.py
@@ -169,10 +169,14 @@ def _revert_proxy_config(config_data: dict, cfg_path: str | None) -> list[str]:
 
     revert_result = None
     if patch_state:
-        revert_result = revert_retroarch_cfg(revert_cfg_path, patch_state)
+        revert_result = revert_retroarch_cfg(
+            revert_cfg_path, patch_state, config_data=config_data
+        )
     elif revert_cfg_path:
         try:
-            revert_result = revert_retroarch_cfg(revert_cfg_path)
+            revert_result = revert_retroarch_cfg(
+                revert_cfg_path, config_data=config_data
+            )
         except Exception:
             revert_result = None
 

--- a/linux/raofflineproxy/main.py
+++ b/linux/raofflineproxy/main.py
@@ -122,7 +122,9 @@ def _apply_proxy(config_data: dict, cfg_path: str) -> list[str]:
     store_dolphin_previous(patch_state, dolphin)
     save_patch_state(patch_state)
 
-    if result["already_patched"]:
+    if not result.get("exists", True):
+        output.append(f"Skipped missing retroarch.cfg at {result['cfg_path']}")
+    elif result["already_patched"]:
         output.append("retroarch.cfg already patched")
     elif result["changed"]:
         output.append("Patched retroarch.cfg")
@@ -174,7 +176,7 @@ def _revert_proxy_config(config_data: dict, cfg_path: str | None) -> list[str]:
         except Exception:
             revert_result = None
 
-    if revert_result is None:
+    if revert_result is None or not revert_result.get("exists", True):
         output.append("retroarch.cfg already reverted")
     elif revert_result["changed"]:
         output.append("Reverted retroarch.cfg")

--- a/linux/raofflineproxy/menu_sdl.py
+++ b/linux/raofflineproxy/menu_sdl.py
@@ -405,10 +405,11 @@ def runtime_config() -> tuple[dict, str]:
     return config_data, cfg_path
 
 
-def start_proxy_inline() -> None:
+def start_proxy_inline() -> bool:
+    """Starts the proxy. Returns True when RetroArch's cfg was missing and skipped."""
     config_data, cfg_path = runtime_config()
     remove_stale_hook()
-    patch_retroarch_cfg(cfg_path, config_data)
+    patch_result = patch_retroarch_cfg(cfg_path, config_data)
     enforce_patched_cfg(cfg_path, config_data)
     batocera = patch_batocera_conf(config_data)
     ppsspp = patch_ppsspp_ini(config_data)
@@ -419,6 +420,7 @@ def start_proxy_inline() -> None:
     store_dolphin_previous(patch_state, dolphin)
     save_patch_state(patch_state)
     start_service_process(config_data)
+    return not patch_result.get("exists", True)
 
 
 def stop_proxy_inline() -> None:
@@ -433,18 +435,18 @@ def stop_proxy_inline() -> None:
     revert_dolphin_ini(config_data, patch_state.get("dolphin_previous", {}))
 
     if patch_state:
-        revert_retroarch_cfg(revert_cfg_path, patch_state)
+        revert_retroarch_cfg(revert_cfg_path, patch_state, config_data=config_data)
         return
 
     if not service.get("already_stopped"):
         try:
-            revert_retroarch_cfg(revert_cfg_path)
+            revert_retroarch_cfg(revert_cfg_path, config_data=config_data)
         except Exception:
             pass
         return
 
     try:
-        revert_retroarch_cfg(revert_cfg_path)
+        revert_retroarch_cfg(revert_cfg_path, config_data=config_data)
     except Exception:
         pass
 
@@ -2660,14 +2662,23 @@ class MenuSdlSession:
 
     def start_proxy(self) -> None:
         try:
+            cfg_skipped = False
             if service_mode_active():
                 start_service()
             else:
-                start_proxy_inline()
+                cfg_skipped = start_proxy_inline()
             self.refresh_main_menu_state(force=True)
             self.maybe_offer_smart_cache()
+            if cfg_skipped:
+                log_menu_sdl("start_proxy retroarch cfg missing, patched conf only")
             if self.view != "smart_cache_prompt":
-                self.message = ("Proxy started", time.monotonic() + 1.2)
+                if cfg_skipped:
+                    self.message = (
+                        "Proxy started, no RetroArch cfg",
+                        time.monotonic() + ERROR_SECONDS,
+                    )
+                else:
+                    self.message = ("Proxy started", time.monotonic() + 1.2)
         except Exception as exc:
             log_action_failure("start_proxy", exc)
             self.message = (f"Start failed: {exc}", time.monotonic() + ERROR_SECONDS)

--- a/linux/raofflineproxy/menu_sdl.py
+++ b/linux/raofflineproxy/menu_sdl.py
@@ -373,6 +373,11 @@ def log_menu_sdl(message: str) -> None:
         handle.write(f"{timestamp} {message}\n")
 
 
+def log_action_failure(action: str, exc: Exception) -> None:
+    log_menu_sdl(f"{action} failed error={exc}")
+    log_menu_sdl(traceback.format_exc().rstrip())
+
+
 def remove_stale_hook() -> None:
     if STALE_HOOK_PATH.exists():
         STALE_HOOK_PATH.unlink()
@@ -2664,6 +2669,7 @@ class MenuSdlSession:
             if self.view != "smart_cache_prompt":
                 self.message = ("Proxy started", time.monotonic() + 1.2)
         except Exception as exc:
+            log_action_failure("start_proxy", exc)
             self.message = (f"Start failed: {exc}", time.monotonic() + ERROR_SECONDS)
 
     def stop_proxy(self) -> None:
@@ -2676,6 +2682,7 @@ class MenuSdlSession:
             self.refresh_main_menu_state(force=True)
             self.message = ("Proxy stopped", time.monotonic() + 1.2)
         except Exception as exc:
+            log_action_failure("stop_proxy", exc)
             self.message = (f"Stop failed: {exc}", time.monotonic() + ERROR_SECONDS)
 
     def toggle_autostart(self, config_data: dict) -> None:
@@ -2695,6 +2702,7 @@ class MenuSdlSession:
                 self.message = ("Autostart enabled", time.monotonic() + 1.2)
             self.refresh_main_menu_state(force=True)
         except Exception as exc:
+            log_action_failure("toggle_autostart", exc)
             self.message = (
                 f"Autostart failed: {exc}",
                 time.monotonic() + ERROR_SECONDS,

--- a/linux/raofflineproxy/retroarch_cfg.py
+++ b/linux/raofflineproxy/retroarch_cfg.py
@@ -310,7 +310,9 @@ def patch_retroarch_cfg(cfg_path: str, config_data: dict) -> dict:
 
 
 def revert_retroarch_cfg(
-    cfg_path: Optional[str] = None, patch_state_override: Optional[dict] = None
+    cfg_path: Optional[str] = None,
+    patch_state_override: Optional[dict] = None,
+    config_data: Optional[dict] = None,
 ) -> dict:
     patch_state = patch_state_override if patch_state_override is not None else load_patch_state()
     target_path = cfg_path or (patch_state or {}).get("cfg_path")
@@ -319,6 +321,12 @@ def revert_retroarch_cfg(
 
     target = Path(target_path)
     if not target.exists():
+        # Only a cfg the conf can regenerate is legitimately absent. Anything else is
+        # a cfg that went missing after being patched, and dropping the saved state
+        # there would strand the proxy host in it with nothing left to restore from.
+        if not conf_fallback_available(config_data or {}):
+            raise FileNotFoundError(f"RetroArch config not found: {target}")
+
         revert_cheevos_append_cfg((patch_state or {}).get("cheevos_append_cfg"))
         if patch_state_override is None and patch_state is not None:
             clear_patch_state()

--- a/linux/raofflineproxy/retroarch_cfg.py
+++ b/linux/raofflineproxy/retroarch_cfg.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 from typing import Optional
 
-from .config import detect_rocknix_append_cfg, proxy_value
+from .config import detect_batocera_conf, detect_rocknix_append_cfg, proxy_value
 from .state import clear_patch_state, load_patch_state, save_patch_state
 
 HOST_KEY = "cheevos_custom_host"
@@ -224,10 +224,33 @@ def build_reverted_content(
     return _upsert_config_value(with_enable, HARDCORE_KEY, "true")
 
 
+def conf_fallback_available(config_data: dict) -> bool:
+    """Whether batocera.conf/knulli.conf can carry the host override on its own.
+
+    Knulli generates retroarchcustom.cfg at the first libretro launch, so it is
+    legitimately absent on a freshly flashed device. Its configgen rebuilds that
+    file from the conf on every launch anyway, making the conf the authoritative
+    patch target there and the missing cfg a no-op rather than a failure.
+    """
+    conf_path = detect_batocera_conf(config_data)
+    return bool(conf_path) and Path(conf_path).exists()
+
+
 def patch_retroarch_cfg(cfg_path: str, config_data: dict) -> dict:
     target = Path(cfg_path)
     if not target.exists():
-        raise FileNotFoundError(f"RetroArch config not found: {target}")
+        if not conf_fallback_available(config_data):
+            raise FileNotFoundError(f"RetroArch config not found: {target}")
+        return {
+            "cfg_path": str(target),
+            "exists": False,
+            "hardcore_was_enabled": False,
+            "previous_enable": None,
+            "previous_host": None,
+            "proxy_host": proxy_value(config_data),
+            "changed": False,
+            "already_patched": False,
+        }
 
     existing_patch_state = load_patch_state() or {}
     original = target.read_text(encoding="utf-8", errors="replace")
@@ -276,6 +299,7 @@ def patch_retroarch_cfg(cfg_path: str, config_data: dict) -> dict:
 
     return {
         "cfg_path": str(target),
+        "exists": True,
         "hardcore_was_enabled": hardcore_was_enabled,
         "previous_enable": previous_enable,
         "previous_host": previous_host,
@@ -295,7 +319,17 @@ def revert_retroarch_cfg(
 
     target = Path(target_path)
     if not target.exists():
-        raise FileNotFoundError(f"RetroArch config not found: {target}")
+        revert_cheevos_append_cfg((patch_state or {}).get("cheevos_append_cfg"))
+        if patch_state_override is None and patch_state is not None:
+            clear_patch_state()
+        return {
+            "cfg_path": str(target),
+            "exists": False,
+            "changed": False,
+            "restored_hardcore": False,
+            "previous_host": "",
+            "used_saved_state": patch_state is not None,
+        }
 
     current = target.read_text(encoding="utf-8", errors="replace")
     previous_host = patch_state.get("previous_host") if patch_state else ""
@@ -327,6 +361,7 @@ def revert_retroarch_cfg(
         clear_patch_state()
     return {
         "cfg_path": str(target),
+        "exists": True,
         "changed": transformed != current,
         "restored_hardcore": restore_hardcore,
         "previous_host": previous_host,

--- a/linux/tests/test_linux_boot_reconcile.py
+++ b/linux/tests/test_linux_boot_reconcile.py
@@ -59,7 +59,7 @@ class RevertProxyConfigTests(unittest.TestCase):
         ):
             output = main._revert_proxy_config({}, "/runtime/retroarch.cfg")
 
-        revert_cfg.assert_called_once_with("/runtime/retroarch.cfg")
+        revert_cfg.assert_called_once_with("/runtime/retroarch.cfg", config_data={})
         start_service.assert_not_called()
         self.assertEqual(output[-1], "Reverted retroarch.cfg")
 
@@ -75,7 +75,9 @@ class RevertProxyConfigTests(unittest.TestCase):
         ):
             main._revert_proxy_config({}, "/runtime/retroarch.cfg")
 
-        revert_cfg.assert_called_once_with("/saved/retroarch.cfg", state)
+        revert_cfg.assert_called_once_with(
+            "/saved/retroarch.cfg", state, config_data={}
+        )
 
 
 class BootReconcileDispatchTests(unittest.TestCase):

--- a/linux/tests/test_linux_config_paths.py
+++ b/linux/tests/test_linux_config_paths.py
@@ -89,6 +89,110 @@ class LinuxConfigPathTests(unittest.TestCase):
             else:
                 os.environ["RAOFFLINEPROXY_RETROARCH_CFG"] = original_override
 
+    def test_detect_retroarch_cfg_falls_back_to_the_next_knulli_candidate(self) -> None:
+        original_override = os.environ.get("RAOFFLINEPROXY_RETROARCH_CFG")
+        original_muos = config.DEFAULT_MUOS_RETROARCH_CFG
+        original_candidates = config.KNULLI_RETROARCH_CFG_CANDIDATES
+        original_exists = Path.exists
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                os.environ.pop("RAOFFLINEPROXY_RETROARCH_CFG", None)
+                config.DEFAULT_MUOS_RETROARCH_CFG = Path(temp_dir) / "missing-muos.cfg"
+                custom_cfg = Path(temp_dir) / "retroarchcustom.cfg"
+                plain_cfg = Path(temp_dir) / "retroarch.cfg"
+                plain_cfg.write_text("", encoding="utf-8")
+                config.KNULLI_RETROARCH_CFG_CANDIDATES = (custom_cfg, plain_cfg)
+
+                def fake_exists(path: Path) -> bool:
+                    if str(path) == "/userdata":
+                        return True
+                    return original_exists(path)
+
+                with mock.patch.object(Path, "exists", fake_exists):
+                    self.assertEqual(config.detect_retroarch_cfg(), str(plain_cfg))
+        finally:
+            config.DEFAULT_MUOS_RETROARCH_CFG = original_muos
+            config.KNULLI_RETROARCH_CFG_CANDIDATES = original_candidates
+            if original_override is None:
+                os.environ.pop("RAOFFLINEPROXY_RETROARCH_CFG", None)
+            else:
+                os.environ["RAOFFLINEPROXY_RETROARCH_CFG"] = original_override
+
+    def test_detect_retroarch_cfg_keeps_the_knulli_path_when_no_candidate_exists(
+        self,
+    ) -> None:
+        original_override = os.environ.get("RAOFFLINEPROXY_RETROARCH_CFG")
+        original_muos = config.DEFAULT_MUOS_RETROARCH_CFG
+        original_candidates = config.KNULLI_RETROARCH_CFG_CANDIDATES
+        original_exists = Path.exists
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                os.environ.pop("RAOFFLINEPROXY_RETROARCH_CFG", None)
+                config.DEFAULT_MUOS_RETROARCH_CFG = Path(temp_dir) / "missing-muos.cfg"
+                custom_cfg = Path(temp_dir) / "retroarchcustom.cfg"
+                plain_cfg = Path(temp_dir) / "retroarch.cfg"
+                config.KNULLI_RETROARCH_CFG_CANDIDATES = (custom_cfg, plain_cfg)
+
+                def fake_exists(path: Path) -> bool:
+                    if str(path) == "/userdata":
+                        return True
+                    return original_exists(path)
+
+                with mock.patch.object(Path, "exists", fake_exists):
+                    self.assertEqual(config.detect_retroarch_cfg(), str(custom_cfg))
+        finally:
+            config.DEFAULT_MUOS_RETROARCH_CFG = original_muos
+            config.KNULLI_RETROARCH_CFG_CANDIDATES = original_candidates
+            if original_override is None:
+                os.environ.pop("RAOFFLINEPROXY_RETROARCH_CFG", None)
+            else:
+                os.environ["RAOFFLINEPROXY_RETROARCH_CFG"] = original_override
+
+    def test_detect_retroarch_cfg_keeps_sdcard_scoped_to_its_own_platform(self) -> None:
+        """A stray home cfg must not outrank the card's own RetroArch config."""
+        original_override = os.environ.get("RAOFFLINEPROXY_RETROARCH_CFG")
+        original_muos = config.DEFAULT_MUOS_RETROARCH_CFG
+        original_exists = Path.exists
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                os.environ.pop("RAOFFLINEPROXY_RETROARCH_CFG", None)
+                config.DEFAULT_MUOS_RETROARCH_CFG = Path(temp_dir) / "missing-muos.cfg"
+                home_cfg = Path.home() / ".config" / "retroarch" / "retroarch.cfg"
+                present = {Path("/mnt/SDCARD"), home_cfg}
+
+                def fake_exists(path: Path) -> bool:
+                    if path in present:
+                        return True
+                    if str(path) in ("/userdata", "/storage"):
+                        return False
+                    return original_exists(path)
+
+                with mock.patch.object(Path, "exists", fake_exists):
+                    with mock.patch.object(
+                        config, "running_on_rocknix", return_value=False
+                    ):
+                        self.assertEqual(
+                            config.detect_retroarch_cfg(),
+                            str(config.SDCARD_RETROARCH_CFG_CANDIDATES[0]),
+                        )
+        finally:
+            config.DEFAULT_MUOS_RETROARCH_CFG = original_muos
+            if original_override is None:
+                os.environ.pop("RAOFFLINEPROXY_RETROARCH_CFG", None)
+            else:
+                os.environ["RAOFFLINEPROXY_RETROARCH_CFG"] = original_override
+
+    def test_detect_retroarch_cfg_env_override_outranks_every_platform(self) -> None:
+        original_override = os.environ.get("RAOFFLINEPROXY_RETROARCH_CFG")
+        try:
+            os.environ["RAOFFLINEPROXY_RETROARCH_CFG"] = "/custom/retroarch.cfg"
+            self.assertEqual(config.detect_retroarch_cfg(), "/custom/retroarch.cfg")
+        finally:
+            if original_override is None:
+                os.environ.pop("RAOFFLINEPROXY_RETROARCH_CFG", None)
+            else:
+                os.environ["RAOFFLINEPROXY_RETROARCH_CFG"] = original_override
+
     def test_detect_batocera_conf_returns_none_on_muos(self) -> None:
         original_override = os.environ.get("RAOFFLINEPROXY_BATOCERA_CONF")
         original_knulli = config.DEFAULT_KNULLI_CONF

--- a/linux/tests/test_linux_retroarch_cfg.py
+++ b/linux/tests/test_linux_retroarch_cfg.py
@@ -7,6 +7,66 @@ from linux.raofflineproxy import retroarch_cfg
 from linux.raofflineproxy import state
 
 
+class LinuxRetroarchMissingCfgTests(unittest.TestCase):
+    """A Knulli device that has never launched a libretro game has no cfg yet."""
+
+    def test_patch_skips_missing_cfg_when_conf_carries_the_override(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cfg_path = Path(temp_dir) / "retroarchcustom.cfg"
+            conf_path = Path(temp_dir) / "knulli.conf"
+            conf_path.write_text("", encoding="utf-8")
+
+            with mock.patch.object(
+                retroarch_cfg, "detect_batocera_conf", return_value=str(conf_path)
+            ):
+                result = retroarch_cfg.patch_retroarch_cfg(str(cfg_path), {})
+
+            self.assertFalse(result["exists"])
+            self.assertFalse(result["changed"])
+            self.assertFalse(result["already_patched"])
+            self.assertFalse(cfg_path.exists())
+
+    def test_patch_still_raises_without_a_conf_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cfg_path = Path(temp_dir) / "retroarch.cfg"
+
+            with mock.patch.object(
+                retroarch_cfg, "detect_batocera_conf", return_value=None
+            ):
+                with self.assertRaises(FileNotFoundError):
+                    retroarch_cfg.patch_retroarch_cfg(str(cfg_path), {})
+
+    def test_patch_still_raises_when_the_conf_itself_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cfg_path = Path(temp_dir) / "retroarch.cfg"
+            conf_path = Path(temp_dir) / "knulli.conf"
+
+            with mock.patch.object(
+                retroarch_cfg, "detect_batocera_conf", return_value=str(conf_path)
+            ):
+                with self.assertRaises(FileNotFoundError):
+                    retroarch_cfg.patch_retroarch_cfg(str(cfg_path), {})
+
+    def test_revert_clears_state_for_a_missing_cfg_instead_of_failing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cfg_path = Path(temp_dir) / "retroarchcustom.cfg"
+            state_path = Path(temp_dir) / "retroarch_patch_state.json"
+            state_path.write_text(
+                '{"cfg_path": "' + str(cfg_path) + '"}\n', encoding="utf-8"
+            )
+
+            original_state_file = state.STATE_FILE
+            try:
+                state.STATE_FILE = state_path
+                result = retroarch_cfg.revert_retroarch_cfg()
+
+                self.assertFalse(result["exists"])
+                self.assertFalse(result["changed"])
+                self.assertIsNone(state.load_patch_state())
+            finally:
+                state.STATE_FILE = original_state_file
+
+
 class LinuxRetroarchCfgTests(unittest.TestCase):
     def test_patch_already_patched_cfg_repairs_saved_previous_host(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/linux/tests/test_linux_retroarch_cfg.py
+++ b/linux/tests/test_linux_retroarch_cfg.py
@@ -50,6 +50,8 @@ class LinuxRetroarchMissingCfgTests(unittest.TestCase):
     def test_revert_clears_state_for_a_missing_cfg_instead_of_failing(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             cfg_path = Path(temp_dir) / "retroarchcustom.cfg"
+            conf_path = Path(temp_dir) / "knulli.conf"
+            conf_path.write_text("", encoding="utf-8")
             state_path = Path(temp_dir) / "retroarch_patch_state.json"
             state_path.write_text(
                 '{"cfg_path": "' + str(cfg_path) + '"}\n', encoding="utf-8"
@@ -58,11 +60,39 @@ class LinuxRetroarchMissingCfgTests(unittest.TestCase):
             original_state_file = state.STATE_FILE
             try:
                 state.STATE_FILE = state_path
-                result = retroarch_cfg.revert_retroarch_cfg()
+                with mock.patch.object(
+                    retroarch_cfg, "detect_batocera_conf", return_value=str(conf_path)
+                ):
+                    result = retroarch_cfg.revert_retroarch_cfg()
 
                 self.assertFalse(result["exists"])
                 self.assertFalse(result["changed"])
                 self.assertIsNone(state.load_patch_state())
+            finally:
+                state.STATE_FILE = original_state_file
+
+    def test_revert_keeps_state_when_a_patched_cfg_went_missing(self) -> None:
+        """No conf fallback means the cfg vanished after being patched: keep the state."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cfg_path = Path(temp_dir) / "retroarch.cfg"
+            state_path = Path(temp_dir) / "retroarch_patch_state.json"
+            state_path.write_text(
+                '{"cfg_path": "' + str(cfg_path) + '", "previous_host": "example.org"}\n',
+                encoding="utf-8",
+            )
+
+            original_state_file = state.STATE_FILE
+            try:
+                state.STATE_FILE = state_path
+                with mock.patch.object(
+                    retroarch_cfg, "detect_batocera_conf", return_value=None
+                ):
+                    with self.assertRaises(FileNotFoundError):
+                        retroarch_cfg.revert_retroarch_cfg()
+
+                saved = state.load_patch_state()
+                assert saved is not None
+                self.assertEqual(saved["previous_host"], "example.org")
             finally:
                 state.STATE_FILE = original_state_file
 

--- a/linux/tests/test_linux_rocknix.py
+++ b/linux/tests/test_linux_rocknix.py
@@ -62,6 +62,30 @@ class RocknixConfigPathTests(unittest.TestCase):
         finally:
             config.DEFAULT_MUOS_RETROARCH_CFG = original_muos
 
+    def test_detect_retroarch_cfg_uses_storage_layout_when_name_check_fails(self) -> None:
+        """running_on_rocknix() returns False on an unreadable /etc/os-release."""
+        original_muos = config.DEFAULT_MUOS_RETROARCH_CFG
+        original_exists = Path.exists
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                config.DEFAULT_MUOS_RETROARCH_CFG = Path(temp_dir) / "missing-muos.cfg"
+
+                def fake_exists(path: Path) -> bool:
+                    if str(path) == "/storage":
+                        return True
+                    if str(path) in ("/userdata", "/mnt/SDCARD"):
+                        return False
+                    return original_exists(path)
+
+                with patch.object(Path, "exists", fake_exists):
+                    with patch.object(config, "running_on_rocknix", return_value=False):
+                        self.assertEqual(
+                            config.detect_retroarch_cfg(),
+                            str(config.DEFAULT_ROCKNIX_RETROARCH_CFG),
+                        )
+        finally:
+            config.DEFAULT_MUOS_RETROARCH_CFG = original_muos
+
     def test_resolve_config_dir_uses_rocknix_dir(self) -> None:
         import os
 

--- a/linux/tests/test_linux_stop_proxy.py
+++ b/linux/tests/test_linux_stop_proxy.py
@@ -5,6 +5,36 @@ from linux.raofflineproxy import main
 from linux.raofflineproxy import menu_sdl
 
 
+class LinuxStartProxyInlineTests(unittest.TestCase):
+    def _start(self, patch_result: dict) -> bool:
+        with (
+            mock.patch.object(
+                menu_sdl, "runtime_config", return_value=({}, "/runtime/retroarch.cfg")
+            ),
+            mock.patch.object(menu_sdl, "remove_stale_hook"),
+            mock.patch.object(
+                menu_sdl, "patch_retroarch_cfg", return_value=patch_result
+            ),
+            mock.patch.object(menu_sdl, "enforce_patched_cfg"),
+            mock.patch.object(menu_sdl, "patch_batocera_conf", return_value={}),
+            mock.patch.object(menu_sdl, "patch_ppsspp_ini", return_value={}),
+            mock.patch.object(menu_sdl, "patch_dolphin_ini", return_value={}),
+            mock.patch.object(menu_sdl, "load_patch_state", return_value={}),
+            mock.patch.object(menu_sdl, "store_batocera_previous"),
+            mock.patch.object(menu_sdl, "store_ppsspp_previous"),
+            mock.patch.object(menu_sdl, "store_dolphin_previous"),
+            mock.patch.object(menu_sdl, "save_patch_state"),
+            mock.patch.object(menu_sdl, "start_service_process"),
+        ):
+            return menu_sdl.start_proxy_inline()
+
+    def test_reports_a_skipped_cfg_so_the_menu_can_say_so(self) -> None:
+        self.assertTrue(self._start({"exists": False, "changed": False}))
+
+    def test_reports_nothing_when_the_cfg_was_patched(self) -> None:
+        self.assertFalse(self._start({"exists": True, "changed": True}))
+
+
 class LinuxStopProxyTests(unittest.TestCase):
     def test_safe_stop_proxy_prefers_saved_patch_cfg_path(self) -> None:
         with (
@@ -27,6 +57,7 @@ class LinuxStopProxyTests(unittest.TestCase):
         revert_cfg.assert_called_once_with(
             "/saved/retroarch.cfg",
             {"cfg_path": "/saved/retroarch.cfg", "batocera_previous": {}},
+            config_data={},
         )
         self.assertEqual(output[-1], "Reverted retroarch.cfg")
 
@@ -48,4 +79,5 @@ class LinuxStopProxyTests(unittest.TestCase):
         revert_cfg.assert_called_once_with(
             "/saved/retroarch.cfg",
             {"cfg_path": "/saved/retroarch.cfg", "batocera_previous": {}},
+            config_data={},
         )


### PR DESCRIPTION
Fixes #111.

RAOfflineProxy patches `/userdata/system/configs/retroarch/retroarchcustom.cfg` on KNULLI and treated that path as always present. KNULLI generates the file at the first libretro launch, so a freshly flashed device whose owner has only logged into RetroAchievements from the ES menu does not have it yet, and `patch_retroarch_cfg` raised before anything else in the start path could run. Every other patch target already degraded gracefully when its file was absent; this was the only one that threw.

Detection had also drifted from what `linux/README.md` documents: 7a4ff03 replaced the existence-checked `/userdata` candidate chain with a single hardcoded path.

## Changes

- `config.py`: `KNULLI_RETROARCH_CFG_CANDIDATES` restores the four documented `/userdata` paths. `detect_retroarch_cfg()` is now a lookup table of (platform gate, candidates) pairs rather than a branch chain, with each platform's first candidate doubling as its fallback, so a device that has not generated its cfg yet still gets a path that belongs to its own platform. Candidates stay scoped to their platform because several firmwares share a card and leave stale folders behind, which is the same masking class cc71c89 solved for the version files. The table is built per call so module globals stay late-bound, which the existing tests rely on.
- `retroarch_cfg.py`: `conf_fallback_available()` now gates the raise. A missing cfg is a no-op when `knulli.conf`/`batocera.conf` is present, since that conf carries `cheevos_custom_host` and configgen rebuilds the cfg from it at every launch. Without a conf fallback it still raises, so a genuinely broken install fails loudly instead of reporting a start that routes nothing. `revert_retroarch_cfg()` mirrors this, otherwise a tolerated start turns into a failing stop on the same missing file.
- `main.py`: reports the skipped cfg instead of claiming a patch that did not happen.
- `menu_sdl.py`: `start_proxy_inline()` returns whether the cfg was skipped, and the menu says `Proxy started, no RetroArch cfg` rather than a plain success. Without this the SDL menu, which is the path most users take, would claim a normal start on a device whose cfg is missing for a bad reason.
- `menu_sdl.py`: start, stop and autostart failures are written to `menu-sdl.log` through the existing `log_menu_sdl` helper. They were previously swallowed into an on-screen toast, which is why the reporter's support log contained nothing about the failure.
- `linux/README.md`: documents the KNULLI fallback behaviour.

## Verification

Simulated the reporter's device state (no cfg, `knulli.conf` present): start writes `cheevos_custom_host` into the conf and succeeds, stop reverts it cleanly, and no stray cfg file is created.

Compared old and new detection across 13 device shapes. Ten are identical; three change deliberately: the KNULLI candidate chain, `/mnt/SDCARD` no longer losing to a stray home cfg, and `/storage` taking precedence over `/mnt/SDCARD` on a device that has both, which is not a shape any of the four firmware families produces.

`revert_retroarch_cfg()` only discards saved patch state when the conf can regenerate the cfg. A cfg that went missing after being patched still raises, so stop cannot silently drop the record of what to restore and strand the proxy host in the file.

Tests: `python3 -m pytest linux/tests/` passes with 463, including 12 new ones covering the candidate chain, the skip and the menu signal, both cases that must still raise, the revert in both directions, the platform scoping, the ROCKNIX-by-layout gate and the env override.

Not verified on hardware. A test build is with the reporter on #111.
