### PR TITLE
Export Onion timezone so local timestamps are not rendered as UTC

### DIFF
--- a/linux/onion/app/RAOfflineProxy/common.sh
+++ b/linux/onion/app/RAOfflineProxy/common.sh
@@ -14,6 +14,7 @@ APP_ONION_STARTUP_DIR=/mnt/SDCARD/.tmp_update/startup
 APP_ONION_AUTOSTART_SCRIPT="$APP_ONION_STARTUP_DIR/raofflineproxy.sh"
 APP_ONION_CHECKOFF_DIR=/mnt/SDCARD/.tmp_update/checkoff
 APP_ONION_CHECKOFF_SCRIPT="$APP_ONION_CHECKOFF_DIR/raofflineproxy.sh"
+APP_ONION_TZ_FILE=/mnt/SDCARD/.tmp_update/config/.tz
 APP_ACTIVE_RUNTIME_ROOT=
 RESOLVED_PYTHON_BIN=
 RUNTIME_FAILURE_REASON=
@@ -36,9 +37,31 @@ normalize_display_paths() {
     sed 's#/mnt/SDCARD/#/#g'
 }
 
+resolve_onion_timezone() {
+    # Onion exports TZ only for MainUI and its game launcher, so an app started
+    # from the Apps list or a startup hook inherits an empty TZ and renders
+    # every local timestamp as UTC.
+    if [ -n "${TZ:-}" ]; then
+        return 0
+    fi
+
+    if [ ! -r "$APP_ONION_TZ_FILE" ]; then
+        return 0
+    fi
+
+    onion_tz="$(cat "$APP_ONION_TZ_FILE" 2>/dev/null || true)"
+    if [ -n "$onion_tz" ]; then
+        export TZ="$onion_tz"
+    fi
+
+    return 0
+}
+
 prepare_env() {
     mkdir -p "$APP_DATA_DIR"
     : > "$RUNTIME_DETECT_LOG"
+
+    resolve_onion_timezone
 
     if [ -f /mnt/SDCARD/.tmp_update/config/retroarch.cfg ]; then
         APP_RETROARCH_CFG=/mnt/SDCARD/.tmp_update/config/retroarch.cfg


### PR DESCRIPTION
Fixes #112

Onion keeps the timezone in `/mnt/SDCARD/.tmp_update/config/.tz` and only exports it as `TZ` for MainUI and its game launcher (`set_tzid` in `update_networking.sh`, `TZ="$TZ_VALUE" $sysdir/cmd_to_run.sh` in `runtime.sh`). It never maintains `/etc/localtime`, so an app started from the Apps list or a startup hook inherits an empty `TZ` and libc falls through to UTC. That is why the reporter sees the same offset in SSH and in other apps.

`prepare_env` now reads that file when `TZ` is unset, which covers both entry points in one place: `launch.sh` (menu, and the `run-service` child that inherits its env) and `autostart-launch.sh` (boot-reconcile).

Impact was display-only. `queued_at` comes from `current_millis()` and nothing submitted to RA carries local time, so no stored data was wrong; only the pending-awards date column (`pending_awards.py`) and log timestamps (`menu_sdl.py`) rendered in UTC.

### Verification

- `sh -n` clean.
- Sourced and exercised all four paths, each returning 0 (callers run `set -eu` and call `prepare_env` bare): `.tz` present -> `TZ=UTC-02:00`; file missing -> unset; file empty -> unset; `TZ` already inherited -> inherited value wins.
- Confirmed the POSIX string shifts Python: with `TZ=UTC-02:00`, `time.strftime` renders 21:25 against 19:25 UTC. The zone abbreviation renders as `UTC`, but neither affected format string uses `%Z`.

### Scope

Onion-specific by design. muOS, ROCKNIX, Knulli, RetroDECK and DarkOS all maintain `/etc/localtime`, so libc resolves the zone correctly with `TZ` unset, and none of their launchers scrub the environment. spruce is unverified and worth a look when that branch comes back around, since it targets the same Miyoo stock-firmware family and has no TZ handling either.
