### PR TITLE
Add ARMSX1/ARMSX2 smart cache support

### DIFF
--- a/app/src/main/java/com/raofflineproxy/proxy/SmartCache.kt
+++ b/app/src/main/java/com/raofflineproxy/proxy/SmartCache.kt
@@ -31,9 +31,16 @@ private const val TAG = "RAProxy/SmartCache"
 private const val DOLPHIN_RECENT_WINDOW_MS = 60L * 24 * 60 * 60 * 1000
 private const val RETROARCH_RECENT_WINDOW_MS = 60L * 24 * 60 * 60 * 1000
 private const val WATERMELONDS_RECENT_WINDOW_MS = 60L * 24 * 60 * 60 * 1000
+private const val ARMSX_RECENT_WINDOW_MS = 60L * 24 * 60 * 60 * 1000
 
 private val WATERMELONDS_ROM_LIBRARY_AUTHORITIES by lazy {
     Emulator.WatermelonDs.packageCandidates.map { packageName -> "$packageName.romlibrary" }
+}
+private val ARMSX1_ROM_LIBRARY_AUTHORITIES by lazy {
+    Emulator.Armsx1.packageCandidates.map { packageName -> "$packageName.romlibrary" }
+}
+private val ARMSX2_ROM_LIBRARY_AUTHORITIES by lazy {
+    Emulator.Armsx2.packageCandidates.map { packageName -> "$packageName.romlibrary" }
 }
 private val SMART_CACHE_EXT_STORAGE by lazy { Environment.getExternalStorageDirectory().path }
 
@@ -155,7 +162,9 @@ internal enum class SmartCacheEmulator {
     RetroArch,
     Dolphin,
     Ppsspp,
-    WatermelonDs
+    WatermelonDs,
+    Armsx1,
+    Armsx2
 }
 
 internal data class SmartCacheCandidate(
@@ -548,6 +557,91 @@ private fun queryWatermelonDsRomLibrary(context: Context, authority: String, cut
     }.getOrNull()
 }
 
+private object Armsx1SmartCacheStrategy : SmartCacheStrategy {
+    override val emulator: SmartCacheEmulator = SmartCacheEmulator.Armsx1
+
+    override fun isEnabled(context: Context, emulatorSupport: EmulatorSupport): Boolean =
+        emulatorSupport.isInstalled(Emulator.Armsx1) &&
+            emulatorSupport.isEnabled(Emulator.Armsx1)
+
+    override fun discoverCandidates(context: Context, treeUri: Uri?): SmartCacheStrategyResult =
+        discoverArmsxCandidates(context, SmartCacheEmulator.Armsx1, ARMSX1_ROM_LIBRARY_AUTHORITIES)
+}
+
+private object Armsx2SmartCacheStrategy : SmartCacheStrategy {
+    override val emulator: SmartCacheEmulator = SmartCacheEmulator.Armsx2
+
+    override fun isEnabled(context: Context, emulatorSupport: EmulatorSupport): Boolean =
+        emulatorSupport.isInstalled(Emulator.Armsx2) &&
+            emulatorSupport.isEnabled(Emulator.Armsx2)
+
+    override fun discoverCandidates(context: Context, treeUri: Uri?): SmartCacheStrategyResult =
+        discoverArmsxCandidates(context, SmartCacheEmulator.Armsx2, ARMSX2_ROM_LIBRARY_AUTHORITIES)
+}
+
+private fun discoverArmsxCandidates(context: Context, emulator: SmartCacheEmulator, authorities: List<String>): SmartCacheStrategyResult {
+    val cutoff = System.currentTimeMillis() - ARMSX_RECENT_WINDOW_MS
+    val candidates = authorities.firstNotNullOfOrNull { authority ->
+        queryArmsxRomLibrary(context, authority, emulator, cutoff)
+    }
+
+    if (candidates == null) {
+        Log.i(TAG, "$emulator strategy did not find a readable rom library provider")
+        return SmartCacheStrategyResult(message = "no_recent_games")
+    }
+    if (candidates.isEmpty()) {
+        Log.i(TAG, "$emulator strategy found no recently played games within the last ${ARMSX_RECENT_WINDOW_MS / (24L * 60 * 60 * 1000)} days")
+        return SmartCacheStrategyResult(message = "no_recent_games")
+    }
+
+    Log.i(TAG, "$emulator strategy discovered ${candidates.size} recently played candidates")
+    return SmartCacheStrategyResult(candidates = candidates)
+}
+
+private fun queryArmsxRomLibrary(context: Context, authority: String, emulator: SmartCacheEmulator, cutoff: Long): List<SmartCacheCandidate>? {
+    val uri = Uri.Builder()
+        .scheme("content")
+        .authority(authority)
+        .appendPath("games")
+        .build()
+
+    return runCatching {
+        context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+            val titleIndex = cursor.getColumnIndex("title")
+            val uriIndex = cursor.getColumnIndex("uri")
+            val lastPlayedIndex = cursor.getColumnIndex("lastPlayed")
+
+            buildList {
+                while (cursor.moveToNext()) {
+                    val lastPlayed = if (lastPlayedIndex >= 0 && !cursor.isNull(lastPlayedIndex)) {
+                        cursor.getLong(lastPlayedIndex)
+                    } else {
+                        null
+                    }
+                    if (lastPlayed == null || lastPlayed < cutoff) {
+                        continue
+                    }
+
+                    val romUri = uriIndex.takeIf { it >= 0 }?.let { cursor.getString(it) } ?: continue
+                    val title = titleIndex.takeIf { it >= 0 }?.let { cursor.getString(it) }
+
+                    add(
+                        SmartCacheCandidate(
+                            emulator = emulator,
+                            sourceLabel = authority,
+                            path = romUri,
+                            title = title,
+                            lastModifiedAt = lastPlayed
+                        )
+                    )
+                }
+            }
+        }
+    }.onFailure { error ->
+        Log.i(TAG, "$emulator strategy could not query authority=$authority", error)
+    }.getOrNull()
+}
+
 internal suspend fun runSmartCache(
     context: Context,
     credentials: LoginCredentials,
@@ -577,7 +671,7 @@ internal suspend fun runSmartCache(
         )
     }
 
-    val activeStrategies = listOf(RetroArchSmartCacheStrategy, DolphinSmartCacheStrategy, PpssppSmartCacheStrategy, WatermelonDsSmartCacheStrategy)
+    val activeStrategies = listOf(RetroArchSmartCacheStrategy, DolphinSmartCacheStrategy, PpssppSmartCacheStrategy, WatermelonDsSmartCacheStrategy, Armsx1SmartCacheStrategy, Armsx2SmartCacheStrategy)
         .filter { strategy -> strategy.isEnabled(context, emulatorSupport) }
     if (activeStrategies.isEmpty()) {
         Log.i(TAG, "runSmartCache found no active strategies")
@@ -601,6 +695,8 @@ internal suspend fun runSmartCache(
             SmartCacheEmulator.Dolphin -> dolphinTreeUri
             SmartCacheEmulator.Ppsspp -> ppssppTreeUri
             SmartCacheEmulator.WatermelonDs -> null
+            SmartCacheEmulator.Armsx1 -> null
+            SmartCacheEmulator.Armsx2 -> null
         }
         val result = strategy.discoverCandidates(context, treeUri)
         Log.i(
@@ -712,7 +808,7 @@ internal suspend fun runSmartCache(
     }
     Log.i(
         TAG,
-        "runSmartCache readable cap=$candidateCap resolved=${preflight.resolved.size} capped=${resolvedCandidates.size} remainingSlots=$remainingSlots retroArchSelected=${resolvedCandidates.count { it.candidate.emulator == SmartCacheEmulator.RetroArch }} dolphinSelected=${resolvedCandidates.count { it.candidate.emulator == SmartCacheEmulator.Dolphin }} ppssppSelected=${resolvedCandidates.count { it.candidate.emulator == SmartCacheEmulator.Ppsspp }} watermelonDsSelected=${resolvedCandidates.count { it.candidate.emulator == SmartCacheEmulator.WatermelonDs }}"
+        "runSmartCache readable cap=$candidateCap resolved=${preflight.resolved.size} capped=${resolvedCandidates.size} remainingSlots=$remainingSlots retroArchSelected=${resolvedCandidates.count { it.candidate.emulator == SmartCacheEmulator.RetroArch }} dolphinSelected=${resolvedCandidates.count { it.candidate.emulator == SmartCacheEmulator.Dolphin }} ppssppSelected=${resolvedCandidates.count { it.candidate.emulator == SmartCacheEmulator.Ppsspp }} watermelonDsSelected=${resolvedCandidates.count { it.candidate.emulator == SmartCacheEmulator.WatermelonDs }} armsx1Selected=${resolvedCandidates.count { it.candidate.emulator == SmartCacheEmulator.Armsx1 }} armsx2Selected=${resolvedCandidates.count { it.candidate.emulator == SmartCacheEmulator.Armsx2 }}"
     )
 
     val relevantTotal = resolvedCandidates.size
@@ -1495,6 +1591,10 @@ private fun resolveDocumentByStoredUri(context: Context, path: String): Document
 }
 
 private fun String.toAbsoluteStoragePath(): String? {
+    if (startsWith("file://", ignoreCase = true)) {
+        return runCatching { this.toUri() }.getOrNull()?.path
+    }
+
     if (!startsWith("content://", ignoreCase = true)) {
         return null
     }

--- a/app/src/main/java/com/raofflineproxy/ui/MainViewModel.kt
+++ b/app/src/main/java/com/raofflineproxy/ui/MainViewModel.kt
@@ -1656,6 +1656,8 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
                                 SmartCacheEmulator.Dolphin -> add(SafGrantTarget.Dolphin)
                                 SmartCacheEmulator.Ppsspp -> add(SafGrantTarget.Ppsspp)
                                 SmartCacheEmulator.WatermelonDs -> Unit
+                                SmartCacheEmulator.Armsx1 -> Unit
+                                SmartCacheEmulator.Armsx2 -> Unit
                             }
                         }
                         if (result.message == "needs_retroarch_shared_access") {


### PR DESCRIPTION
Adds `Armsx1SmartCacheStrategy` and `Armsx2SmartCacheStrategy`, sharing one query helper, that pull recently played games from ARMSX2's `RecentGamesContentProvider` (title, file URI, serial, lastPlayed). Unlike WatermelonDS, ARMSX2 doesn't precompute an RA hash, so these candidates go through the normal hash-then-lookup path.

Also fixes `toAbsoluteStoragePath()` to handle `file://` URIs, not just `content://`. ARMSX2's provider returns plain `file://` paths, and those were falling through unresolved.

Upstream is merged and shipped: ARMSX2/ARMSX2#566, released in 2.6.6.8. ARMSX1 carries the same patch in ARMSX2/ARMSX1#10 (still open).

Verified end-to-end on-device before rebase: OutRun 2006 matched RA gameId 20859 and cached; a second PS2 game correctly got a real "no match" from RA's own API (unrecognized dump, not a bug).

Replaces #88, which was invalidated when #87 was squash-merged. Rebased onto the current `main` and ported to the new `Emulator` enum API (`isInstalled`/`isEnabled`, `packageCandidates`) — package candidate lists and installed/enabled semantics are equivalent to the old per-emulator booleans.

Tracked in #33.