### PR TITLE
muos: clear cheevos_custom_host from retroarch.cheevos.cfg on stop

### DIFF
--- a/linux/raofflineproxy/retroarch_cfg.py
+++ b/linux/raofflineproxy/retroarch_cfg.py
@@ -47,12 +47,38 @@ def patch_cheevos_append_cfg(cfg_path: str | None, config_data: dict) -> dict | 
     if transformed != original:
         target.write_text(transformed, encoding="utf-8")
 
+    if _is_proxy_host(previous_host, config_data):
+        previous_host = ""
+
     return {
         "cfg_path": str(target),
         "hardcore_was_enabled": hardcore_was_enabled,
         "previous_enable": previous_enable,
         "previous_host": previous_host,
         "changed": transformed != original,
+    }
+
+
+def clear_cheevos_append_host(cfg_path: str | None, config_data: dict | None) -> dict | None:
+    """Blind cleanup of the appendconfig, for when the saved patch state cannot
+    describe it: the state was lost (crash, manual edit), or muOS created the file
+    after the patch ran. Only a host pointing at our own proxy is cleared, so a
+    genuinely custom host survives."""
+    target = cheevos_append_cfg_path(cfg_path)
+    if target is None or not target.exists():
+        return None
+
+    current = target.read_text(encoding="utf-8", errors="replace")
+    if not _is_proxy_host(_extract_config_value(current, HOST_KEY), config_data or {}):
+        return None
+
+    transformed = _upsert_config_value(current, HOST_KEY, "")
+    if transformed != current:
+        target.write_text(transformed, encoding="utf-8")
+
+    return {
+        "cfg_path": str(target),
+        "changed": transformed != current,
     }
 
 
@@ -344,9 +370,13 @@ def patch_retroarch_cfg(cfg_path: str, config_data: dict) -> dict:
         hardcore_was_enabled = bool(
             existing_patch_state.get("hardcore_was_enabled", hardcore_was_enabled)
         )
-        cheevos_append_state = existing_patch_state.get(
-            "cheevos_append_cfg", cheevos_append_state
-        )
+        # Only the saved state knows what the appendconfig looked like before the
+        # first patch. Keep the fresh one when nothing was saved for that file,
+        # which is the case when muOS created it after the patch ran.
+        saved_append_state = existing_patch_state.get("cheevos_append_cfg")
+        append_path = str(cheevos_append_cfg_path(str(target)))
+        if saved_append_state and saved_append_state.get("cfg_path") == append_path:
+            cheevos_append_state = saved_append_state
 
     save_patch_state(
         {
@@ -391,6 +421,7 @@ def revert_retroarch_cfg(
             raise FileNotFoundError(f"RetroArch config not found: {target}")
 
         revert_cheevos_append_cfg((patch_state or {}).get("cheevos_append_cfg"))
+        clear_cheevos_append_host(str(target), config_data)
         if patch_state_override is None and patch_state is not None:
             clear_patch_state()
         return {
@@ -427,6 +458,7 @@ def revert_retroarch_cfg(
         target.write_text(transformed, encoding="utf-8")
 
     revert_cheevos_append_cfg((patch_state or {}).get("cheevos_append_cfg"))
+    clear_cheevos_append_host(str(target), config_data)
 
     if patch_state_override is None and patch_state is not None:
         clear_patch_state()
@@ -478,6 +510,30 @@ def enforce_patched_cfg(cfg_path: str, config_data: dict) -> bool:
 
     target.write_text(transformed, encoding="utf-8")
     return True
+
+
+LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1")
+
+
+def _is_proxy_host(value: str | None, config_data: dict) -> bool:
+    """Whether a cheevos_custom_host value is one of ours. The port is ignored on
+    loopback so a host left behind by an earlier run (or a since-changed proxy port)
+    is still recognised."""
+    if not value:
+        return False
+
+    address = value.strip()
+    if address == proxy_value(config_data):
+        return True
+
+    for scheme in ("http://", "https://"):
+        if address.startswith(scheme):
+            address = address[len(scheme) :]
+            break
+
+    address = address.rstrip("/")
+    host = address.rsplit(":", 1)[0] if ":" in address else address
+    return host.strip("[]") in LOOPBACK_HOSTS
 
 
 def _extract_config_value(content: str, key: str) -> str | None:

--- a/linux/tests/e2e/README.md
+++ b/linux/tests/e2e/README.md
@@ -112,7 +112,7 @@ offline award queue-and-flush cycle, and offline reads from cache.
 | --- | --- | --- | --- |
 | knulli | aarch64 | self-extracting `.sh` | 19 |
 | rocknix | aarch64 | self-extracting `.sh` | 20 |
-| muos | aarch64 | `.muxapp` zip | 22 |
+| muos | aarch64 | `.muxapp` zip | 26 |
 | onion | armv7 | SD-card zip | 21 |
 | spruce | armv7 | SD-card zip | 23 |
 | allium | armv7 | SD-card zip | 21 |
@@ -129,8 +129,10 @@ tag matching the interpreter.
 `launch.sh` exporting `RAOFFLINEPROXY_CONFIG_DIR` and `..._RETROARCH_CFG` itself
 (the one place the harness does not fight an env override, because the shipping
 product sets it); `detect_batocera_conf()` returning `None`; autostart writing
-both `init/raofflineproxy.sh` and the `advanced/user_init` flag; and theme
-icons actually being removed by the uninstaller (see below).
+both `init/raofflineproxy.sh` and the `advanced/user_init` flag; the
+`retroarch.cheevos.cfg` appendconfig being patched *and* cleared on stop, including
+when the saved patch state is gone or the file only appeared after the patch ran
+(issue #132); and theme icons actually being removed by the uninstaller (see below).
 
 **Miyoo family** (`_miyoo_common.py`, subclassed per device) — the bundled armv7
 CPython 3.9 being the interpreter `resolve_python_bin` actually selects rather

--- a/linux/tests/e2e/rootfs/Dockerfile.muos
+++ b/linux/tests/e2e/rootfs/Dockerfile.muos
@@ -41,6 +41,9 @@ RUN mkdir -p \
     && chmod +x /opt/muos/script/mux/frontend.sh
 
 COPY rootfs/muos/retroarch.cfg /opt/muos/share/info/config/retroarch.cfg
+# muOS launches RetroArch with this file as --appendconfig, so it outranks
+# retroarch.cfg for every cheevos key.
+COPY rootfs/muos/retroarch.cheevos.cfg /opt/muos/share/info/config/retroarch.cheevos.cfg
 
 ENV HOME=/root
 ENV PATH=/opt/busybox-bin:/usr/local/bin:/usr/bin:/bin

--- a/linux/tests/e2e/rootfs/muos/retroarch.cheevos.cfg
+++ b/linux/tests/e2e/rootfs/muos/retroarch.cheevos.cfg
@@ -1,0 +1,6 @@
+cheevos_custom_host = ""
+cheevos_enable = "true"
+cheevos_username = "testuser"
+cheevos_password = ""
+cheevos_token = "tok-testuser-000000000001"
+cheevos_hardcore_mode_enable = "true"

--- a/linux/tests/e2e/scenarios/test_muos_lifecycle.py
+++ b/linux/tests/e2e/scenarios/test_muos_lifecycle.py
@@ -9,6 +9,7 @@ MSLUG_GAME_ID = 1447
 
 HARDCORE_KEY = "cheevos_hardcore_mode_enable"
 CUSTOM_HOST_KEY = "cheevos_custom_host"
+CHEEVOS_CFG = "/opt/muos/share/info/config/retroarch.cheevos.cfg"
 USER_INIT = "/opt/muos/config/settings/advanced/user_init"
 THEME_ICON = "/run/muos/storage/theme/default/glyph/muxapp/raofflineproxy.png"
 
@@ -121,6 +122,50 @@ class TestProxyLifecycle:
         installed.cli.run("stop-proxy", check=True)
         cfg = installed.container.read_file(installed.device.retroarch_cfg)
         assert cfg_value(cfg, HARDCORE_KEY) == "false"
+
+
+class TestCheevosAppendConfig:
+    """muOS passes retroarch.cheevos.cfg to RetroArch as --appendconfig, so a proxy
+    host left behind there outranks the reverted retroarch.cfg (issue #132)."""
+
+    def test_start_patches_the_appendconfig(self, installed):
+        installed.cli.run("start-proxy", check=True)
+        cfg = installed.container.read_file(CHEEVOS_CFG)
+        assert cfg_value(cfg, CUSTOM_HOST_KEY) == installed.device.proxy_value
+        assert cfg_value(cfg, HARDCORE_KEY) == "false"
+
+    def test_stop_clears_the_appendconfig(self, installed):
+        installed.cli.run("start-proxy", check=True)
+        installed.cli.run("stop-proxy", check=True)
+        cfg = installed.container.read_file(CHEEVOS_CFG)
+        assert cfg_value(cfg, CUSTOM_HOST_KEY) == ""
+        assert cfg_value(cfg, HARDCORE_KEY) == "true"
+
+    def test_stop_clears_the_appendconfig_without_patch_state(self, installed):
+        """What a crash or an app swiped away leaves behind: the saved state is gone,
+        so the revert has to recognise its own host in the file."""
+        installed.cli.run("start-proxy", check=True)
+        installed.container.exec(
+            "rm -f %s/retroarch_patch_state.json" % installed.device.config_dir,
+            check=True,
+        )
+        installed.cli.run("stop-proxy", check=True)
+        cfg = installed.container.read_file(CHEEVOS_CFG)
+        assert cfg_value(cfg, CUSTOM_HOST_KEY) == ""
+
+    def test_appendconfig_created_after_the_patch_is_still_cleared(self, installed):
+        installed.container.exec("mv %s /tmp/cheevos.cfg" % CHEEVOS_CFG, check=True)
+        installed.cli.run("start-proxy", check=True)
+        installed.container.exec("mv /tmp/cheevos.cfg %s" % CHEEVOS_CFG, check=True)
+        installed.cli.run("start-proxy", check=True)
+        assert (
+            cfg_value(installed.container.read_file(CHEEVOS_CFG), CUSTOM_HOST_KEY)
+            == installed.device.proxy_value
+        )
+
+        installed.cli.run("stop-proxy", check=True)
+        cfg = installed.container.read_file(CHEEVOS_CFG)
+        assert cfg_value(cfg, CUSTOM_HOST_KEY) == ""
 
 
 class TestAutostart:
@@ -240,6 +285,9 @@ class TestUninstall:
         cfg = installed.container.read_file(installed.device.retroarch_cfg)
         assert cfg_value(cfg, HARDCORE_KEY) == "true"
         assert cfg_value(cfg, CUSTOM_HOST_KEY) == ""
+
+        cheevos_cfg = installed.container.read_file(CHEEVOS_CFG)
+        assert cfg_value(cheevos_cfg, CUSTOM_HOST_KEY) == ""
 
     def test_uninstall_removes_the_theme_icon(self, installed):
         """Regression: uninstall.sh used `find -delete`, which BusyBox find does

--- a/linux/tests/test_linux_retroarch_cfg.py
+++ b/linux/tests/test_linux_retroarch_cfg.py
@@ -259,3 +259,105 @@ class LinuxRocknixMenuCredentialTests(unittest.TestCase):
                 retroarch_cfg, "detect_rocknix_system_cfg", return_value=None
             ):
                 self.assertIsNone(retroarch_cfg.load_retroarch_credentials(str(cfg)))
+
+
+class CheevosAppendCfgRevertTests(unittest.TestCase):
+    """muOS launches RetroArch with retroarch.cheevos.cfg as an --appendconfig, so a
+    proxy host left behind there outranks the reverted retroarch.cfg (issue #132)."""
+
+    CFG = 'cheevos_custom_host = "%s"\ncheevos_enable = "true"\n'
+
+    def _device(self, temp_dir: str, append_host: str):
+        cfg_path = Path(temp_dir) / "retroarch.cfg"
+        append_path = Path(temp_dir) / "retroarch.cheevos.cfg"
+        cfg_path.write_text(self.CFG % "127.0.0.1:8080", encoding="utf-8")
+        append_path.write_text(self.CFG % append_host, encoding="utf-8")
+        return cfg_path, append_path
+
+    def test_revert_without_patch_state_clears_the_appendconfig(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cfg_path, append_path = self._device(temp_dir, "127.0.0.1:8080")
+            state_path = Path(temp_dir) / "retroarch_patch_state.json"
+
+            original_state_file = state.STATE_FILE
+            try:
+                state.STATE_FILE = state_path
+                retroarch_cfg.revert_retroarch_cfg(str(cfg_path))
+            finally:
+                state.STATE_FILE = original_state_file
+
+            self.assertIn(
+                'cheevos_custom_host = ""',
+                append_path.read_text(encoding="utf-8"),
+            )
+
+    def test_revert_keeps_a_host_that_is_not_ours(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cfg_path, append_path = self._device(temp_dir, "cheevos.example.org")
+            state_path = Path(temp_dir) / "retroarch_patch_state.json"
+
+            original_state_file = state.STATE_FILE
+            try:
+                state.STATE_FILE = state_path
+                retroarch_cfg.revert_retroarch_cfg(str(cfg_path))
+            finally:
+                state.STATE_FILE = original_state_file
+
+            self.assertIn(
+                'cheevos_custom_host = "cheevos.example.org"',
+                append_path.read_text(encoding="utf-8"),
+            )
+
+    def test_revert_clears_a_host_left_by_a_different_proxy_port(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cfg_path, append_path = self._device(temp_dir, "http://127.0.0.1:8099")
+            state_path = Path(temp_dir) / "retroarch_patch_state.json"
+
+            original_state_file = state.STATE_FILE
+            try:
+                state.STATE_FILE = state_path
+                retroarch_cfg.revert_retroarch_cfg(str(cfg_path))
+            finally:
+                state.STATE_FILE = original_state_file
+
+            self.assertIn(
+                'cheevos_custom_host = ""',
+                append_path.read_text(encoding="utf-8"),
+            )
+
+    def test_appendconfig_created_after_the_first_patch_is_reverted(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cfg_path = Path(temp_dir) / "retroarch.cfg"
+            append_path = Path(temp_dir) / "retroarch.cheevos.cfg"
+            state_path = Path(temp_dir) / "retroarch_patch_state.json"
+            cfg_path.write_text(self.CFG % "", encoding="utf-8")
+
+            original_state_file = state.STATE_FILE
+            try:
+                state.STATE_FILE = state_path
+                retroarch_cfg.patch_retroarch_cfg(str(cfg_path), {})
+                self.assertIsNone(state.load_patch_state()["cheevos_append_cfg"])
+
+                append_path.write_text(self.CFG % "", encoding="utf-8")
+                retroarch_cfg.patch_retroarch_cfg(str(cfg_path), {})
+                saved = state.load_patch_state()["cheevos_append_cfg"]
+                self.assertEqual(saved["cfg_path"], str(append_path))
+
+                retroarch_cfg.revert_retroarch_cfg(str(cfg_path))
+            finally:
+                state.STATE_FILE = original_state_file
+
+            self.assertIn(
+                'cheevos_custom_host = ""',
+                append_path.read_text(encoding="utf-8"),
+            )
+
+    def test_patch_of_an_already_patched_appendconfig_forgets_the_proxy_host(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cfg_path, _ = self._device(temp_dir, "127.0.0.1:8080")
+
+            patched = retroarch_cfg.patch_cheevos_append_cfg(str(cfg_path), {})
+
+            self.assertEqual(patched["previous_host"], "")


### PR DESCRIPTION
Fixes #132

muOS launches RetroArch with `retroarch.cheevos.cfg` as an `--appendconfig`, so its
`cheevos_custom_host` outranks `retroarch.cfg`. Reverting that file depended entirely on
the `cheevos_append_cfg` sub-state in `retroarch_patch_state.json`, which fails in two
ways:

- **state lost** (no clean stop, `data/` cleared) — the blind revert cleaned
  `retroarch.cfg` and had nothing to clean the appendconfig with
- **appendconfig appeared after the first patch** — the saved sub-state was `null`, and
  the already-patched branch reinstated that `null` on every later start, so the revert
  kept skipping the file

Either way RetroArch keeps logging in against `127.0.0.1` after a stop.

## Changes

- `clear_cheevos_append_host()` runs on every revert path: clears the appendconfig host
  when it is ours (exact proxy value, or any loopback host so a changed port is still
  caught), leaves a genuinely custom host untouched
- `patch_cheevos_append_cfg()` records `previous_host = ""` when it finds our own proxy
  there, so a re-patch cannot "restore" the proxy
- the already-patched branch keeps freshly computed append state when nothing was saved
  for that path

Scoped to `<dir-of-retroarch.cfg>/retroarch.cheevos.cfg`, which exists on muOS only.
ROCKNIX's lowerdeck chain writes its loopback host into `/tmp/.retroarch.cfg`, a
different file, so it is unaffected.

## Tests

- 5 unit cases in `test_linux_retroarch_cfg.py`, incl. a non-loopback host surviving a
  revert
- 4 muOS container scenarios plus an appendconfig assert in the uninstall test, with a
  `retroarch.cheevos.cfg` added to the muOS rootfs
- verified on hardware with the built `1.12.0-alpha1` `.muxapp`: start, normal stop, stop
  with the state file deleted, appendconfig appearing after the first patch, custom host
  preserved, and the SDL menu's start/stop path
