### PR TITLE
ci: run the e2e device matrix on every linux pull request

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,28 @@ on:
   workflow_dispatch:
 
 jobs:
-  linux-tests:
+  # Both linux jobs gate on this, so the definition of "a linux change" lives in
+  # one place. Pull requests only: the other events run everything unconditionally.
+  changes:
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    outputs:
+      linux: ${{ steps.filter.outputs.linux }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            linux:
+              - 'linux/**'
+              - 'third_party/**'
+              - '.github/workflows/tests.yml'
+
+  linux-tests:
+    needs: changes
+    if: needs.changes.outputs.linux == 'true'
     runs-on: ubuntu-latest
     steps:
       # rcheevos and libchdr are submodules; the native hasher is built from them.
@@ -18,31 +38,19 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: dorny/paths-filter@v4
-        id: changes
-        with:
-          filters: |
-            linux:
-              - 'linux/**'
-              - 'third_party/**'
-
       - uses: actions/setup-python@v7
-        if: steps.changes.outputs.linux == 'true'
         with:
           python-version: "3.14"
 
       - name: Install test dependencies
-        if: steps.changes.outputs.linux == 'true'
         run: pip install pytest
 
       # Without a loadable libraproxy_rchash the hashing tests skip themselves,
       # so the suite would stay green while every ROM format goes untested.
       - name: Build native hasher
-        if: steps.changes.outputs.linux == 'true'
         run: TARGET=host OUT_DIR="${{ runner.temp }}/rchash" bash linux/build_rchash.sh
 
       - name: Run linux tests
-        if: steps.changes.outputs.linux == 'true'
         env:
           RAOFFLINEPROXY_RCHASH_LIB: ${{ runner.temp }}/rchash/libraproxy_rchash.so
         run: python3 -m pytest linux/tests/
@@ -90,13 +98,21 @@ jobs:
   # server. See linux/tests/e2e/README.md.
   #
   # Every architecture is emulated on the x86_64 runners, so this is far slower
-  # than the unit suites. It runs nightly and on demand, and on a pull request
-  # only when that PR carries the "e2e" label.
+  # than the unit suites. It runs nightly, on demand, and on any pull request
+  # that touches linux/ — the "e2e" label forces it on a PR that does not.
+  #
+  # !cancelled() is what lets the nightly and dispatch runs through: "changes" is
+  # skipped there, and a skipped dependency would otherwise skip this job whatever
+  # the condition below says.
   linux-e2e:
     name: e2e (${{ matrix.device }})
+    needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'e2e')
+      !cancelled() && (
+        github.event_name != 'pull_request' ||
+        needs.changes.outputs.linux == 'true' ||
+        contains(github.event.pull_request.labels.*.name, 'e2e')
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:


### PR DESCRIPTION
The `e2e` label gate never fired in practice: the label did not exist in the repo, and
adding one to an open PR does not re-trigger the workflow anyway (`pull_request` defaults
to `opened, synchronize, reopened` — not `labeled`). So the device matrix only ever ran
nightly or on demand, and a linux change could merge without it.

Now any pull request touching `linux/`, `third_party/` or this workflow runs the full
matrix. The `e2e` label still works as an override for a PR that touches none of those.

## Changes

- new `changes` job runs `dorny/paths-filter` once and exports a `linux` output, so the
  definition of "a linux change" lives in one place instead of being duplicated per job
- `linux-tests` gates on that output and skips as a whole job, rather than running a job
  whose every step is individually skipped
- `linux-e2e` gains `needs: changes` and runs when the filter matched, when the `e2e`
  label is present, or on any non-PR event

`!cancelled()` in the `linux-e2e` condition is load-bearing: `changes` is skipped on the
nightly and `workflow_dispatch` runs, and a skipped dependency would otherwise skip the
job no matter what the condition evaluates to.

Since the filter includes this workflow, this PR runs the matrix on itself.

## Cost

Six emulated legs per linux PR. If that turns out to be too slow in practice, the natural
trim is one leg per arch/install shape on PRs (`knulli` + `onion`) with all six kept
nightly.
