### PR TITLE
Fix miyoo e2e Dockerfile: bump base image off EOL bullseye

### DIFF
--- a/linux/tests/e2e/rootfs/Dockerfile.miyoo
+++ b/linux/tests/e2e/rootfs/Dockerfile.miyoo
@@ -1,8 +1,15 @@
-FROM arm32v7/debian:bullseye-slim
+FROM arm32v7/debian:bookworm-slim
 
 # Onion, spruce and Allium are the same Miyoo Mini hardware sharing one SD card
 # layout; only a handful of marker files tell the three firmwares apart. One
 # image with a FIRMWARE build-arg keeps that relationship explicit.
+#
+# The base is bookworm, not bullseye: the Miyoo firmwares ship their own
+# CPython 3.9 inside the bundle (see README.md), so the system python only
+# needs to be something resolve_python_bin must not pick, not a version
+# match. bullseye's security pool stopped serving the pinned package files
+# apt-get update's index referenced once bullseye went EOL, breaking the
+# build; bookworm is what darkos/muos/knulli already use.
 ARG FIRMWARE=onion
 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- `Dockerfile.miyoo` was still on `arm32v7/debian:bullseye-slim`; bullseye is now EOL and its `-security` pool stopped serving several pinned armhf package files, so `apt-get install` 404s and the `e2e (onion/allium/spruce)` jobs fail on PR #142.
- Moves the base image to `bookworm-slim`, matching what `Dockerfile.darkos`, `Dockerfile.muos`, and `Dockerfile.knulli` already use.
- Safe because the Miyoo firmwares ship their own bundled CPython 3.9 runtime; the tests only assert that bundled interpreter is picked over the system one, so the base image's system Python version was never load-bearing here (unlike ROCKNIX/muOS/Knulli, where it's pinned to match a vendored pygame ABI).

## Test plan
- [ ] CI: `e2e (onion)`, `e2e (allium)`, `e2e (spruce)` jobs pass on the new base image