### PR TITLE
Onion: log the menu texture path and guard the full_resolution marker

### DIFF
--- a/linux/onion/README.md
+++ b/linux/onion/README.md
@@ -97,6 +97,7 @@ App/
     checkoff-template.sh
     common.sh
     config.json
+    full_resolution
     icon.png
     launch.sh
     onion-menu.sh
@@ -104,6 +105,16 @@ App/
 ```
 
 The shared Python package is copied into `App/RAOfflineProxy/app/raofflineproxy` during the bundle build.
+
+## Full Resolution Marker
+
+`App/RAOfflineProxy/full_resolution` is Onion's opt-in for the native panel mode. It must exist and must stay empty: Onion's `runtime.sh` derives the path from the App launch command and only tests for its existence, the same way stock Onion does for DraStic.
+
+Without it, Onion launches the app in MainUI's 640x480 framebuffer mode on 752x560-capable devices such as the Miyoo Mini V4 and the Miyoo Flip, while `/tmp/screen_resolution` already reports the detected panel. The menu then sizes itself for a framebuffer it does not get.
+
+Devices without a 560p panel are unaffected. Onion only consults the marker when `/tmp/new_res_available` exists, and it restores 640x480 after the app exits.
+
+Because the file cannot carry a comment, `linux/tests/test_linux_onion_full_resolution.py` guards it against being cleaned up as stray cruft.
 
 ## Menu
 

--- a/linux/raofflineproxy/menu_sdl.py
+++ b/linux/raofflineproxy/menu_sdl.py
@@ -291,12 +291,21 @@ def _init_onion_display(pygame):
     try:
         texture = Texture(renderer, panel_size, streaming=True)
         texture_surface = draw_surface
-    except RuntimeError:
+        log_menu_sdl(f"onion display texture native size={panel_size[0]}x{panel_size[1]}")
+    except RuntimeError as exc:
         # The vendored "Mini" SDL2 driver's swiftshader renderer caps
         # streaming textures at 640x480 regardless of the actual panel
         # (e.g. the Miyoo Mini Flip's 750x560 screen exceeds it). Present
         # through a capped-size texture and let SDL_RenderCopy scale it
-        # back up to the real panel size.
+        # back up to the real panel size. The renderer is sized from the
+        # live framebuffer at init, so this also trips when the panel is
+        # 560p but Onion launched the app in MainUI's 640x480 mode (i.e.
+        # the App/RAOfflineProxy/full_resolution marker is missing).
+        log_menu_sdl(
+            f"onion display texture {panel_size[0]}x{panel_size[1]} rejected "
+            f"({exc}), scaling through "
+            f"{ONION_DEFAULT_PANEL_SIZE[0]}x{ONION_DEFAULT_PANEL_SIZE[1]}"
+        )
         texture_surface = pygame.Surface(ONION_DEFAULT_PANEL_SIZE, depth=16)
         texture = Texture(renderer, ONION_DEFAULT_PANEL_SIZE, streaming=True)
 

--- a/linux/tests/test_linux_onion_full_resolution.py
+++ b/linux/tests/test_linux_onion_full_resolution.py
@@ -1,0 +1,35 @@
+import unittest
+from pathlib import Path
+
+LINUX_DIR = Path(__file__).resolve().parents[1]
+ONION_APP_DIR = LINUX_DIR / "onion" / "app" / "RAOfflineProxy"
+FULL_RESOLUTION_MARKER = ONION_APP_DIR / "full_resolution"
+BUILD_BUNDLE = LINUX_DIR / "onion" / "build_bundle.sh"
+
+# Onion's runtime.sh derives this path from the App launch command
+# (get_full_resolution_path: `cmd_to_run.sh | cut -d' ' -f 2 | sed 's/;/\/full_resolution/'`)
+# and only tests for its existence. Without it, runtime launches the app in MainUI's
+# 640x480 mode while /tmp/screen_resolution already reports the detected 752x560 panel,
+# so menu_sdl lays out for a framebuffer it does not get. The file is empty by design and
+# nothing else in the tree references it, which is exactly what makes it easy to delete by
+# mistake.
+
+
+class OnionFullResolutionMarkerTests(unittest.TestCase):
+    def test_marker_exists_and_is_empty(self):
+        self.assertTrue(
+            FULL_RESOLUTION_MARKER.is_file(),
+            f"{FULL_RESOLUTION_MARKER} is missing — Onion launches the menu at 640x480 without it",
+        )
+        self.assertEqual(
+            FULL_RESOLUTION_MARKER.stat().st_size,
+            0,
+            "the marker must stay empty: runtime.sh only tests for its existence",
+        )
+
+    def test_bundle_copies_the_whole_app_dir(self):
+        self.assertIn(
+            'cp -R "${SCRIPT_DIR}/app/RAOfflineProxy/." "${APP_DIR}/"',
+            BUILD_BUNDLE.read_text(encoding="utf-8"),
+            "the marker ships only because the bundle copies the app dir wholesale",
+        )


### PR DESCRIPTION
Follow-up to #152.

### Logging

`_init_onion_display` falls back to a 640x480 streaming texture when the panel-sized one is rejected, and then scales every frame down and back up. That fallback was silent, so the on-device log could not say which path ran.

Both branches now log. A 560p device's `menu-sdl.log` will say either:

```text
onion display texture native size=752x560
onion display texture 752x560 rejected (...), scaling through 640x480
```

This is what settles the open question from #152: the rejection plausibly only happened because the renderer is sized from the live framebuffer at init, which was still MainUI's 640x480. With the marker in place the renderer should come up at 560p and the full-size texture should succeed, removing the scaled path entirely.

### Marker guard

`App/RAOfflineProxy/full_resolution` is empty by design and nothing in the tree referenced it, which is exactly what makes a zero-byte file easy to delete as cruft. Adds a test asserting it exists, is empty, and that `build_bundle.sh` still copies the app dir wholesale (the only reason it ships), plus a README section explaining the mechanism since the file cannot carry a comment.

### Testing

`python3 -m pytest linux/tests -q --ignore=linux/tests/e2e` — 570 passed, 17 skipped. Verified the new test fails when the marker is moved away.